### PR TITLE
#166 - Prevent NPE when accessing out of bound line

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
@@ -1216,7 +1216,7 @@ public class BenchmarkScore extends AbstractMojo {
             for (int i = 0; i <= lineNum; i++) {
                 line = br.readLine();
             }
-            while (line.length() == 0) { // Skip empty lines
+            while (line != null && line.length() == 0) { // Skip empty lines
                 line = br.readLine();
             }
             return line;


### PR DESCRIPTION
Fixes https://github.com/OWASP-Benchmark/BenchmarkJava/issues/166. The error only occurs if the result file of Semgrep is single-line (BenchmarkScore.java:932 attempts to read second line which leads to NPE in BenchmarkScore.java:1219)