### PR TITLE
#182 - extend PMDReader to "read" FbInfer report

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/PMDReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/PMDReader.java
@@ -35,7 +35,8 @@ public class PMDReader extends Reader {
 
     @Override
     public boolean canRead(ResultFile resultFile) {
-        return resultFile.filename().endsWith(".xml") && resultFile.line(1).startsWith("<pmd ");
+        return resultFile.filename().endsWith(".xml") 
+                && resultFile.xmlRootNodeName().equals("pmd");
     }
 
     @Override
@@ -147,6 +148,11 @@ public class PMDReader extends Reader {
                 return 78; // command injection
             case "??10":
                 return 79; // XSS
+
+            // FbInfer additional rules
+            case "RESOURCE_LEAK":
+            case "NULL_DEREFERENCE":
+                return 0;
 
             default:
                 System.out.println("Unknown category: " + rule);


### PR DESCRIPTION
Adressing https://github.com/OWASP-Benchmark/BenchmarkJava/issues/182.

This does not add an additional reader because FbInfer is either PMD with Facebook logo on it or exporting compatible XML format. Either way, it's just about code quality and not about vulnerabilities. With this PR PMDReader accepts FbInfer files and does not complain about it.

@davewichers reject if you prefer a copy of PMDReader that reports as FbInfer (still having a score of 0% 😅)