### PR TITLE
Snyk: Include EnvCommandInjection rule mapping

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SnykReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SnykReader.java
@@ -28,6 +28,7 @@ public class SnykReader extends Reader {
                     put("SpringCSRF", CweNumber.CSRF);
                     put("TrustBoundaryViolation", CweNumber.TRUST_BOUNDARY_VIOLATION);
                     put("CommandInjection", CweNumber.COMMAND_INJECTION);
+                    put("EnvCommandInjection", CweNumber.COMMAND_INJECTION);
                     put("DOMXSS", CweNumber.XSS);
                     put("XSS", CweNumber.XSS);
                     put("InsecureCipherNoIntegrity", CweNumber.WEAK_CRYPTO_ALGO);


### PR DESCRIPTION
`EnvCommandInjection` covers injections into the environment, and are handled under a different CWE mapping by Snyk Code.