### PR TITLE
CodeQL update

### DIFF
--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/CodeQLReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/CodeQLReaderTest.java
@@ -1,0 +1,23 @@
+package org.owasp.benchmarkutils.score.parsers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.owasp.benchmarkutils.score.BenchmarkScore;
+import org.owasp.benchmarkutils.score.ResultFile;
+import org.owasp.benchmarkutils.score.TestHelper;
+
+public class CodeQLReaderTest extends ReaderTestBase {
+
+    private ResultFile resultFile;
+
+    @BeforeEach
+    void setUp() {
+        resultFile = TestHelper.resultFileOf("testfiles/Benchmark_CodeQL_2.12.5.sarif");
+        BenchmarkScore.TESTCASENAME = "BenchmarkTest";
+    }
+
+    @Test
+    void onlySnykReaderReportsCanReadAsTrue() {
+        assertOnlyMatcherClassIs(this.resultFile, CodeQLReader.class);
+    }
+}

--- a/plugin/src/test/resources/testfiles/Benchmark_CodeQL_2.12.5.sarif
+++ b/plugin/src/test/resources/testfiles/Benchmark_CodeQL_2.12.5.sarif
@@ -1,0 +1,2905 @@
+{
+    "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "CodeQL",
+                    "organization": "GitHub",
+                    "semanticVersion": "2.12.5",
+                    "notifications": [
+                        {
+                            "id": "java/baseline/expected-extracted-files",
+                            "name": "java/baseline/expected-extracted-files",
+                            "shortDescription": {
+                                "text": "Expected extracted files"
+                            },
+                            "fullDescription": {
+                                "text": "Files appearing in the source archive that are expected to be extracted."
+                            },
+                            "defaultConfiguration": {
+                                "enabled": true
+                            },
+                            "properties": {
+                                "tags": [
+                                    "expected-extracted-files",
+                                    "telemetry"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "js/baseline/expected-extracted-files",
+                            "name": "js/baseline/expected-extracted-files",
+                            "shortDescription": {
+                                "text": "Expected extracted files"
+                            },
+                            "fullDescription": {
+                                "text": "Files appearing in the source archive that are expected to be extracted."
+                            },
+                            "defaultConfiguration": {
+                                "enabled": true
+                            },
+                            "properties": {
+                                "tags": [
+                                    "expected-extracted-files",
+                                    "telemetry"
+                                ]
+                            }
+                        }
+                    ],
+                    "rules": []
+                },
+                "extensions": [
+                    {
+                        "name": "codeql/ruby-examples",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ruby-examples/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ruby-examples/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/python-queries",
+                        "semanticVersion": "0.6.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/python-queries/0.6.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/python-queries/0.6.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/javascript-examples",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/javascript-examples/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/javascript-examples/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/go-examples",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/go-examples/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/go-examples/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/go-queries",
+                        "semanticVersion": "0.4.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/go-queries/0.4.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/go-queries/0.4.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/swift-queries",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/swift-queries/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/swift-queries/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/typetracking",
+                        "semanticVersion": "0.0.6+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/typetracking/0.0.6/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/typetracking/0.0.6/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/java-all",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/java-all/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/java-all/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/javascript-all",
+                        "semanticVersion": "0.5.1+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/javascript-all/0.5.1/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/javascript-all/0.5.1/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/cpp-all",
+                        "semanticVersion": "0.6.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/cpp-all/0.6.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/cpp-all/0.6.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/python-all",
+                        "semanticVersion": "0.8.2+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/python-all/0.8.2/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/python-all/0.8.2/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/csharp-queries",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/csharp-queries/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/csharp-queries/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/javascript-queries",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/javascript-queries/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/javascript-queries/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/suite-helpers",
+                        "semanticVersion": "0.4.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/suite-helpers/0.4.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/suite-helpers/0.4.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/ssa",
+                        "semanticVersion": "0.0.13+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ssa/0.0.13/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ssa/0.0.13/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/swift-all",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/swift-all/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/swift-all/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/go-all",
+                        "semanticVersion": "0.4.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/go-all/0.4.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/go-all/0.4.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/csharp-all",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/csharp-all/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/csharp-all/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/java-examples",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/java-examples/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/java-examples/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/cpp-queries",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/cpp-queries/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/cpp-queries/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/java-queries",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "notifications": [
+                            {
+                                "id": "java/diagnostics/successfully-extracted-files",
+                                "name": "java/diagnostics/successfully-extracted-files",
+                                "shortDescription": {
+                                    "text": "Successfully extracted files"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of all files in the source code directory that were extracted without encountering an error in the file."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "successfully-extracted-files"
+                                    ],
+                                    "description": "A list of all files in the source code directory that\n              were extracted without encountering an error in the file.",
+                                    "id": "java/diagnostics/successfully-extracted-files",
+                                    "kind": "diagnostic",
+                                    "name": "Successfully extracted files"
+                                }
+                            },
+                            {
+                                "id": "java/diagnostics/extraction-warnings",
+                                "name": "java/diagnostics/extraction-warnings",
+                                "shortDescription": {
+                                    "text": "Extraction warnings"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of extraction warnings for files in the source code directory."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "description": "A list of extraction warnings for files in the source code directory.",
+                                    "id": "java/diagnostics/extraction-warnings",
+                                    "kind": "diagnostic",
+                                    "name": "Extraction warnings"
+                                }
+                            },
+                            {
+                                "id": "java/diagnostics/extraction-errors",
+                                "name": "java/diagnostics/extraction-errors",
+                                "shortDescription": {
+                                    "text": "Extraction errors"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of extraction errors for files in the source code directory."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "description": "A list of extraction errors for files in the source code directory.",
+                                    "id": "java/diagnostics/extraction-errors",
+                                    "kind": "diagnostic",
+                                    "name": "Extraction errors"
+                                }
+                            }
+                        ],
+                        "rules": [
+                            {
+                                "id": "java/implicit-cast-in-compound-assignment",
+                                "name": "java/implicit-cast-in-compound-assignment",
+                                "shortDescription": {
+                                    "text": "Implicit narrowing conversion in compound assignment"
+                                },
+                                "fullDescription": {
+                                    "text": "Compound assignment statements (for example 'intvar += longvar') that implicitly cast a value of a wider type to a narrower type may result in information loss and numeric errors such as overflows."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Implicit narrowing conversion in compound assignment\nCompound assignment statements of the form `x += y` or `x *= y` perform an implicit narrowing conversion if the type of `x` is narrower than the type of `y`. For example, `x += y` is equivalent to `x = (T)(x + y)`, where `T` is the type of `x`. This can result in information loss and numeric errors such as overflows.\n\n\n## Recommendation\nEnsure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side.\n\n\n## Example\nIf `x` is of type `short` and `y` is of type `int`, the expression `x + y` is of type `int`. However, the expression `x += y` is equivalent to `x = (short) (x + y)`. The expression `x + y` is cast to the type of the left-hand side of the assignment: `short`, possibly leading to information loss.\n\nTo avoid implicitly narrowing the type of `x + y`, change the type of `x` to `int`. Then the types of `x` and `x + y` are both `int` and there is no need for an implicit cast.\n\n\n## References\n* J. Bloch and N. Gafter, *Java Puzzlers: Traps, Pitfalls, and Corner Cases*, Puzzle 9. Addison-Wesley, 2005.\n* Java Language Specification: [Compound Assignment Operators](https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.26.2), [Narrowing Primitive Conversion](https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html#jls-5.1.3).\n* SEI CERT Oracle Coding Standard for Java: [NUM00-J. Detect or prevent integer overflow](https://wiki.sei.cmu.edu/confluence/display/java/NUM00-J.+Detect+or+prevent+integer+overflow).\n* Common Weakness Enumeration: [CWE-190](https://cwe.mitre.org/data/definitions/190.html).\n* Common Weakness Enumeration: [CWE-192](https://cwe.mitre.org/data/definitions/192.html).\n* Common Weakness Enumeration: [CWE-197](https://cwe.mitre.org/data/definitions/197.html).\n* Common Weakness Enumeration: [CWE-681](https://cwe.mitre.org/data/definitions/681.html).\n",
+                                    "markdown": "# Implicit narrowing conversion in compound assignment\nCompound assignment statements of the form `x += y` or `x *= y` perform an implicit narrowing conversion if the type of `x` is narrower than the type of `y`. For example, `x += y` is equivalent to `x = (T)(x + y)`, where `T` is the type of `x`. This can result in information loss and numeric errors such as overflows.\n\n\n## Recommendation\nEnsure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side.\n\n\n## Example\nIf `x` is of type `short` and `y` is of type `int`, the expression `x + y` is of type `int`. However, the expression `x += y` is equivalent to `x = (short) (x + y)`. The expression `x + y` is cast to the type of the left-hand side of the assignment: `short`, possibly leading to information loss.\n\nTo avoid implicitly narrowing the type of `x + y`, change the type of `x` to `int`. Then the types of `x` and `x + y` are both `int` and there is no need for an implicit cast.\n\n\n## References\n* J. Bloch and N. Gafter, *Java Puzzlers: Traps, Pitfalls, and Corner Cases*, Puzzle 9. Addison-Wesley, 2005.\n* Java Language Specification: [Compound Assignment Operators](https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.26.2), [Narrowing Primitive Conversion](https://docs.oracle.com/javase/specs/jls/se11/html/jls-5.html#jls-5.1.3).\n* SEI CERT Oracle Coding Standard for Java: [NUM00-J. Detect or prevent integer overflow](https://wiki.sei.cmu.edu/confluence/display/java/NUM00-J.+Detect+or+prevent+integer+overflow).\n* Common Weakness Enumeration: [CWE-190](https://cwe.mitre.org/data/definitions/190.html).\n* Common Weakness Enumeration: [CWE-192](https://cwe.mitre.org/data/definitions/192.html).\n* Common Weakness Enumeration: [CWE-197](https://cwe.mitre.org/data/definitions/197.html).\n* Common Weakness Enumeration: [CWE-681](https://cwe.mitre.org/data/definitions/681.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "reliability",
+                                        "security",
+                                        "external/cwe/cwe-190",
+                                        "external/cwe/cwe-192",
+                                        "external/cwe/cwe-197",
+                                        "external/cwe/cwe-681"
+                                    ],
+                                    "description": "Compound assignment statements (for example 'intvar += longvar') that implicitly\n              cast a value of a wider type to a narrower type may result in information loss and\n              numeric errors such as overflows.",
+                                    "id": "java/implicit-cast-in-compound-assignment",
+                                    "kind": "problem",
+                                    "name": "Implicit narrowing conversion in compound assignment",
+                                    "precision": "very-high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "8.1"
+                                }
+                            },
+                            {
+                                "id": "java/weak-cryptographic-algorithm",
+                                "name": "java/weak-cryptographic-algorithm",
+                                "shortDescription": {
+                                    "text": "Use of a broken or risky cryptographic algorithm"
+                                },
+                                "fullDescription": {
+                                    "text": "Using broken or weak cryptographic algorithms can allow an attacker to compromise security."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Use of a broken or risky cryptographic algorithm\nUsing broken or weak cryptographic algorithms can leave data vulnerable to being decrypted.\n\nMany cryptographic algorithms provided by cryptography libraries are known to be weak, or flawed. Using such an algorithm means that an attacker may be able to easily decrypt the encrypted data.\n\n\n## Recommendation\nEnsure that you use a strong, modern cryptographic algorithm. Use at least AES-128 or RSA-2048. Do not use the ECB encryption mode since it is vulnerable to replay and other attacks.\n\n\n## Example\nThe following code shows an example of using a java `Cipher` to encrypt some data. When creating a `Cipher` instance, you must specify the encryption algorithm to use. The first example uses DES, which is an older algorithm that is now considered weak. The second example uses AES, which is a strong modern algorithm.\n\n\n```java\n// BAD: DES is a weak algorithm \nCipher des = Cipher.getInstance(\"DES\");\ncipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);\n\nbyte[] encrypted = cipher.doFinal(input.getBytes(\"UTF-8\"));\n\n// ...\n\n// GOOD: AES is a strong algorithm\nCipher aes = Cipher.getInstance(\"AES\");\n\n// ...\n\n```\n\n## References\n* NIST, FIPS 140 Annex a: [ Approved Security Functions](http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf).\n* NIST, SP 800-131A: [ Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf).\n* Common Weakness Enumeration: [CWE-327](https://cwe.mitre.org/data/definitions/327.html).\n* Common Weakness Enumeration: [CWE-328](https://cwe.mitre.org/data/definitions/328.html).\n",
+                                    "markdown": "# Use of a broken or risky cryptographic algorithm\nUsing broken or weak cryptographic algorithms can leave data vulnerable to being decrypted.\n\nMany cryptographic algorithms provided by cryptography libraries are known to be weak, or flawed. Using such an algorithm means that an attacker may be able to easily decrypt the encrypted data.\n\n\n## Recommendation\nEnsure that you use a strong, modern cryptographic algorithm. Use at least AES-128 or RSA-2048. Do not use the ECB encryption mode since it is vulnerable to replay and other attacks.\n\n\n## Example\nThe following code shows an example of using a java `Cipher` to encrypt some data. When creating a `Cipher` instance, you must specify the encryption algorithm to use. The first example uses DES, which is an older algorithm that is now considered weak. The second example uses AES, which is a strong modern algorithm.\n\n\n```java\n// BAD: DES is a weak algorithm \nCipher des = Cipher.getInstance(\"DES\");\ncipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);\n\nbyte[] encrypted = cipher.doFinal(input.getBytes(\"UTF-8\"));\n\n// ...\n\n// GOOD: AES is a strong algorithm\nCipher aes = Cipher.getInstance(\"AES\");\n\n// ...\n\n```\n\n## References\n* NIST, FIPS 140 Annex a: [ Approved Security Functions](http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf).\n* NIST, SP 800-131A: [ Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf).\n* Common Weakness Enumeration: [CWE-327](https://cwe.mitre.org/data/definitions/327.html).\n* Common Weakness Enumeration: [CWE-328](https://cwe.mitre.org/data/definitions/328.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-327",
+                                        "external/cwe/cwe-328"
+                                    ],
+                                    "description": "Using broken or weak cryptographic algorithms can allow an attacker to compromise security.",
+                                    "id": "java/weak-cryptographic-algorithm",
+                                    "kind": "path-problem",
+                                    "name": "Use of a broken or risky cryptographic algorithm",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/improper-intent-verification",
+                                "name": "java/improper-intent-verification",
+                                "shortDescription": {
+                                    "text": "Improper verification of intent by broadcast receiver"
+                                },
+                                "fullDescription": {
+                                    "text": "A broadcast receiver that does not verify intents it receives may be susceptible to unintended behavior by third party applications sending it explicit intents."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Improper verification of intent by broadcast receiver\nWhen an Android application uses a `BroadcastReceiver` to receive intents, it is also able to receive explicit intents that are sent directly to it, regardless of its filter. Certain intent actions are only able to be sent by the operating system, not third-party applications. However, a `BroadcastReceiver` that is registered to receive system intents is still able to receive intents from a third-party application, so it should check that the intent received has the expected action. Otherwise, a third-party application could impersonate the system this way to cause unintended behavior, such as a denial of service.\n\n\n## Example\nIn the following code, the `ShutdownReceiver` initiates a shutdown procedure upon receiving an intent, without checking that the received action is indeed `ACTION_SHUTDOWN`. This allows third-party applications to send explicit intents to this receiver to cause a denial of service.\n\n\n```java\npublic class ShutdownReceiver extends BroadcastReceiver {\n    @Override\n    public void onReceive(final Context context, final Intent intent) {\n        mainActivity.saveLocalData();\n        mainActivity.stopActivity();\n    }\n}\n```\n\n```xml\n<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" package=\"test\">\n    <application>\n        <receiver android:name=\".BootReceiverXml\">\n            <intent-filter>\n                <action android:name=\"android.intent.action.BOOT_COMPLETED\" />\n            </intent-filter>\n        </receiver>\n    </application>\n</manifest>\n```\n\n## Recommendation\nIn the `onReceive` method of a `BroadcastReceiver`, the action of the received Intent should be checked. The following code demonstrates this.\n\n\n```java\npublic class ShutdownReceiver extends BroadcastReceiver {\n    @Override\n    public void onReceive(final Context context, final Intent intent) {\n        if (!intent.getAction().equals(Intent.ACTION_SHUTDOWN)) {\n            return;\n        }\n        mainActivity.saveLocalData();\n        mainActivity.stopActivity();\n    }\n}\n```\n\n## References\n* Common Weakness Enumeration: [CWE-925](https://cwe.mitre.org/data/definitions/925.html).\n",
+                                    "markdown": "# Improper verification of intent by broadcast receiver\nWhen an Android application uses a `BroadcastReceiver` to receive intents, it is also able to receive explicit intents that are sent directly to it, regardless of its filter. Certain intent actions are only able to be sent by the operating system, not third-party applications. However, a `BroadcastReceiver` that is registered to receive system intents is still able to receive intents from a third-party application, so it should check that the intent received has the expected action. Otherwise, a third-party application could impersonate the system this way to cause unintended behavior, such as a denial of service.\n\n\n## Example\nIn the following code, the `ShutdownReceiver` initiates a shutdown procedure upon receiving an intent, without checking that the received action is indeed `ACTION_SHUTDOWN`. This allows third-party applications to send explicit intents to this receiver to cause a denial of service.\n\n\n```java\npublic class ShutdownReceiver extends BroadcastReceiver {\n    @Override\n    public void onReceive(final Context context, final Intent intent) {\n        mainActivity.saveLocalData();\n        mainActivity.stopActivity();\n    }\n}\n```\n\n```xml\n<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\" package=\"test\">\n    <application>\n        <receiver android:name=\".BootReceiverXml\">\n            <intent-filter>\n                <action android:name=\"android.intent.action.BOOT_COMPLETED\" />\n            </intent-filter>\n        </receiver>\n    </application>\n</manifest>\n```\n\n## Recommendation\nIn the `onReceive` method of a `BroadcastReceiver`, the action of the received Intent should be checked. The following code demonstrates this.\n\n\n```java\npublic class ShutdownReceiver extends BroadcastReceiver {\n    @Override\n    public void onReceive(final Context context, final Intent intent) {\n        if (!intent.getAction().equals(Intent.ACTION_SHUTDOWN)) {\n            return;\n        }\n        mainActivity.saveLocalData();\n        mainActivity.stopActivity();\n    }\n}\n```\n\n## References\n* Common Weakness Enumeration: [CWE-925](https://cwe.mitre.org/data/definitions/925.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-925"
+                                    ],
+                                    "description": "A broadcast receiver that does not verify intents it receives may be susceptible to unintended behavior by third party applications sending it explicit intents.",
+                                    "id": "java/improper-intent-verification",
+                                    "kind": "problem",
+                                    "name": "Improper verification of intent by broadcast receiver",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "8.2"
+                                }
+                            },
+                            {
+                                "id": "java/spel-expression-injection",
+                                "name": "java/spel-expression-injection",
+                                "shortDescription": {
+                                    "text": "Expression language injection (Spring)"
+                                },
+                                "fullDescription": {
+                                    "text": "Evaluation of a user-controlled Spring Expression Language (SpEL) expression may lead to remote code execution."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Expression language injection (Spring)\nThe Spring Expression Language (SpEL) is a powerful expression language provided by the Spring Framework. The language offers many features including invocation of methods available in the JVM. If a SpEL expression is built using attacker-controlled data, and then evaluated in a powerful context, then it may allow the attacker to run arbitrary code.\n\nThe `SpelExpressionParser` class parses a SpEL expression string and returns an `Expression` instance that can be then evaluated by calling one of its methods. By default, an expression is evaluated in a powerful `StandardEvaluationContext` that allows the expression to access other methods available in the JVM.\n\n\n## Recommendation\nIn general, including user input in a SpEL expression should be avoided. If user input must be included in the expression, it should be then evaluated in a limited context that doesn't allow arbitrary method invocation.\n\n\n## Example\nThe following example uses untrusted data to build a SpEL expression and then runs it in the default powerful context.\n\n\n```java\npublic Object evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n      new InputStreamReader(socket.getInputStream()))) {\n\n    String string = reader.readLine();\n    ExpressionParser parser = new SpelExpressionParser();\n    Expression expression = parser.parseExpression(string);\n    return expression.getValue();\n  }\n}\n```\nThe next example shows how an untrusted SpEL expression can be run in `SimpleEvaluationContext` that doesn't allow accessing arbitrary methods. However, it's recommended to avoid using untrusted input in SpEL expressions.\n\n\n```java\npublic Object evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n      new InputStreamReader(socket.getInputStream()))) {\n\n    String string = reader.readLine();\n    ExpressionParser parser = new SpelExpressionParser();\n    Expression expression = parser.parseExpression(string);\n    SimpleEvaluationContext context \n        = SimpleEvaluationContext.forReadWriteDataBinding().build();\n    return expression.getValue(context);\n  }\n}\n```\n\n## References\n* Spring Framework Reference Documentation: [Spring Expression Language (SpEL)](https://docs.spring.io/spring/docs/4.2.x/spring-framework-reference/html/expressions.html).\n* OWASP: [Expression Language Injection](https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+                                    "markdown": "# Expression language injection (Spring)\nThe Spring Expression Language (SpEL) is a powerful expression language provided by the Spring Framework. The language offers many features including invocation of methods available in the JVM. If a SpEL expression is built using attacker-controlled data, and then evaluated in a powerful context, then it may allow the attacker to run arbitrary code.\n\nThe `SpelExpressionParser` class parses a SpEL expression string and returns an `Expression` instance that can be then evaluated by calling one of its methods. By default, an expression is evaluated in a powerful `StandardEvaluationContext` that allows the expression to access other methods available in the JVM.\n\n\n## Recommendation\nIn general, including user input in a SpEL expression should be avoided. If user input must be included in the expression, it should be then evaluated in a limited context that doesn't allow arbitrary method invocation.\n\n\n## Example\nThe following example uses untrusted data to build a SpEL expression and then runs it in the default powerful context.\n\n\n```java\npublic Object evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n      new InputStreamReader(socket.getInputStream()))) {\n\n    String string = reader.readLine();\n    ExpressionParser parser = new SpelExpressionParser();\n    Expression expression = parser.parseExpression(string);\n    return expression.getValue();\n  }\n}\n```\nThe next example shows how an untrusted SpEL expression can be run in `SimpleEvaluationContext` that doesn't allow accessing arbitrary methods. However, it's recommended to avoid using untrusted input in SpEL expressions.\n\n\n```java\npublic Object evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n      new InputStreamReader(socket.getInputStream()))) {\n\n    String string = reader.readLine();\n    ExpressionParser parser = new SpelExpressionParser();\n    Expression expression = parser.parseExpression(string);\n    SimpleEvaluationContext context \n        = SimpleEvaluationContext.forReadWriteDataBinding().build();\n    return expression.getValue(context);\n  }\n}\n```\n\n## References\n* Spring Framework Reference Documentation: [Spring Expression Language (SpEL)](https://docs.spring.io/spring/docs/4.2.x/spring-framework-reference/html/expressions.html).\n* OWASP: [Expression Language Injection](https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-094"
+                                    ],
+                                    "description": "Evaluation of a user-controlled Spring Expression Language (SpEL) expression\n              may lead to remote code execution.",
+                                    "id": "java/spel-expression-injection",
+                                    "kind": "path-problem",
+                                    "name": "Expression language injection (Spring)",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/server-side-template-injection",
+                                "name": "java/server-side-template-injection",
+                                "shortDescription": {
+                                    "text": "Server-side template injection"
+                                },
+                                "fullDescription": {
+                                    "text": "Untrusted input interpreted as a template can lead to remote code execution."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Server-side template injection\nTemplate injection occurs when user input is embedded in a template's code in an unsafe manner. An attacker can use native template syntax to inject a malicious payload into a template, which is then executed server-side. This permits the attacker to run arbitrary code in the server's context.\n\n\n## Recommendation\nTo fix this, ensure that untrusted input is not used as part of a template's code. If the application requirements do not allow this, use a sandboxed environment where access to unsafe attributes and methods is prohibited.\n\n\n## Example\nIn the example given below, an untrusted HTTP parameter `code` is used as a Velocity template string. This can lead to remote code execution.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"bad\")\n\tpublic void bad(HttpServletRequest request) {\n\t\tVelocity.init();\n\n\t\tString code = request.getParameter(\"code\");\n\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tStringWriter w = new StringWriter();\n\t\t// evaluate( Context context, Writer out, String logTag, String instring )\n\t\tVelocity.evaluate(context, w, \"mystring\", code);\n\t}\n}\n\n```\nIn the next example, the problem is avoided by using a fixed template string `s`. Since the template's code is not attacker-controlled in this case, this solution prevents the execution of untrusted code.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"good\")\n\tpublic void good(HttpServletRequest request) {\n\t\tVelocity.init();\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tString s = \"We are using $project $name to render this.\";\n\t\tStringWriter w = new StringWriter();\n\t\tVelocity.evaluate(context, w, \"mystring\", s);\n\t\tSystem.out.println(\" string : \" + w);\n\t}\n}\n\n```\n\n## References\n* Portswigger: [Server Side Template Injection](https://portswigger.net/web-security/server-side-template-injection).\n* Common Weakness Enumeration: [CWE-1336](https://cwe.mitre.org/data/definitions/1336.html).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+                                    "markdown": "# Server-side template injection\nTemplate injection occurs when user input is embedded in a template's code in an unsafe manner. An attacker can use native template syntax to inject a malicious payload into a template, which is then executed server-side. This permits the attacker to run arbitrary code in the server's context.\n\n\n## Recommendation\nTo fix this, ensure that untrusted input is not used as part of a template's code. If the application requirements do not allow this, use a sandboxed environment where access to unsafe attributes and methods is prohibited.\n\n\n## Example\nIn the example given below, an untrusted HTTP parameter `code` is used as a Velocity template string. This can lead to remote code execution.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"bad\")\n\tpublic void bad(HttpServletRequest request) {\n\t\tVelocity.init();\n\n\t\tString code = request.getParameter(\"code\");\n\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tStringWriter w = new StringWriter();\n\t\t// evaluate( Context context, Writer out, String logTag, String instring )\n\t\tVelocity.evaluate(context, w, \"mystring\", code);\n\t}\n}\n\n```\nIn the next example, the problem is avoided by using a fixed template string `s`. Since the template's code is not attacker-controlled in this case, this solution prevents the execution of untrusted code.\n\n\n```java\n@Controller\npublic class VelocitySSTI {\n\n\t@GetMapping(value = \"good\")\n\tpublic void good(HttpServletRequest request) {\n\t\tVelocity.init();\n\t\tVelocityContext context = new VelocityContext();\n\n\t\tcontext.put(\"name\", \"Velocity\");\n\t\tcontext.put(\"project\", \"Jakarta\");\n\n\t\tString s = \"We are using $project $name to render this.\";\n\t\tStringWriter w = new StringWriter();\n\t\tVelocity.evaluate(context, w, \"mystring\", s);\n\t\tSystem.out.println(\" string : \" + w);\n\t}\n}\n\n```\n\n## References\n* Portswigger: [Server Side Template Injection](https://portswigger.net/web-security/server-side-template-injection).\n* Common Weakness Enumeration: [CWE-1336](https://cwe.mitre.org/data/definitions/1336.html).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-1336",
+                                        "external/cwe/cwe-094"
+                                    ],
+                                    "description": "Untrusted input interpreted as a template can lead to remote code execution.",
+                                    "id": "java/server-side-template-injection",
+                                    "kind": "path-problem",
+                                    "name": "Server-side template injection",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/jexl-expression-injection",
+                                "name": "java/jexl-expression-injection",
+                                "shortDescription": {
+                                    "text": "Expression language injection (JEXL)"
+                                },
+                                "fullDescription": {
+                                    "text": "Evaluation of a user-controlled JEXL expression may lead to arbitrary code execution."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Expression language injection (JEXL)\nJava EXpression Language (JEXL) is a simple expression language provided by the Apache Commons JEXL library. The syntax is close to a mix of ECMAScript and shell-script. The language allows invocation of methods available in the JVM. If a JEXL expression is built using attacker-controlled data, and then evaluated, then it may allow the attacker to run arbitrary code.\n\n\n## Recommendation\nIt is generally recommended to avoid using untrusted input in a JEXL expression. If it is not possible, JEXL expressions should be run in a sandbox that allows accessing only explicitly allowed classes.\n\n\n## Example\nThe following example uses untrusted data to build and run a JEXL expression.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n        new InputStreamReader(socket.getInputStream()))) {\n    \n    String input = reader.readLine();\n    JexlEngine jexl = new JexlBuilder().create();\n    JexlExpression expression = jexl.createExpression(input);\n    JexlContext context = new MapContext();\n    expression.evaluate(context);\n  }\n}\n```\nThe next example shows how an untrusted JEXL expression can be run in a sandbox that allows accessing only methods in the `java.lang.Math` class. The sandbox is implemented using `JexlSandbox` class that is provided by Apache Commons JEXL 3.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n        new InputStreamReader(socket.getInputStream()))) {\n    \n    JexlSandbox onlyMath = new JexlSandbox(false);\n    onlyMath.white(\"java.lang.Math\");\n    JexlEngine jexl = new JexlBuilder().sandbox(onlyMath).create();\n      \n    String input = reader.readLine();\n    JexlExpression expression = jexl.createExpression(input);\n    JexlContext context = new MapContext();\n    expression.evaluate(context);\n  }\n}\n```\nThe next example shows another way how a sandbox can be implemented. It uses a custom implementation of `JexlUberspect` that checks if callees are instances of allowed classes.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n        new InputStreamReader(socket.getInputStream()))) {\n    \n    JexlUberspect sandbox = new JexlUberspectSandbox();\n    JexlEngine jexl = new JexlBuilder().uberspect(sandbox).create();\n      \n    String input = reader.readLine();\n    JexlExpression expression = jexl.createExpression(input);\n    JexlContext context = new MapContext();\n    expression.evaluate(context);\n  }\n\n  private static class JexlUberspectSandbox implements JexlUberspect {\n\n    private static final List<String> ALLOWED_CLASSES =\n              Arrays.asList(\"java.lang.Math\", \"java.util.Random\");\n\n    private final JexlUberspect uberspect = new JexlBuilder().create().getUberspect();\n\n    private void checkAccess(Object obj) {\n      if (!ALLOWED_CLASSES.contains(obj.getClass().getCanonicalName())) {\n        throw new AccessControlException(\"Not allowed\");\n      }\n    }\n\n    @Override\n    public JexlMethod getMethod(Object obj, String method, Object... args) {\n      checkAccess(obj);\n      return uberspect.getMethod(obj, method, args);\n    }\n\n    @Override\n    public List<PropertyResolver> getResolvers(JexlOperator op, Object obj) {\n      checkAccess(obj);\n      return uberspect.getResolvers(op, obj);\n    }\n\n    @Override\n    public void setClassLoader(ClassLoader loader) {\n      uberspect.setClassLoader(loader);\n    }\n\n    @Override\n    public int getVersion() {\n      return uberspect.getVersion();\n    }\n\n    @Override\n    public JexlMethod getConstructor(Object obj, Object... args) {\n      checkAccess(obj);\n      return uberspect.getConstructor(obj, args);\n    }\n\n    @Override\n    public JexlPropertyGet getPropertyGet(Object obj, Object identifier) {\n      checkAccess(obj);\n      return uberspect.getPropertyGet(obj, identifier);\n    }\n\n    @Override\n    public JexlPropertyGet getPropertyGet(List<PropertyResolver> resolvers, Object obj, Object identifier) {\n      checkAccess(obj);\n      return uberspect.getPropertyGet(resolvers, obj, identifier);\n    }\n\n    @Override\n    public JexlPropertySet getPropertySet(Object obj, Object identifier, Object arg) {\n      checkAccess(obj);\n      return uberspect.getPropertySet(obj, identifier, arg);\n    }\n\n    @Override\n    public JexlPropertySet getPropertySet(List<PropertyResolver> resolvers, Object obj, Object identifier, Object arg) {\n      checkAccess(obj);\n      return uberspect.getPropertySet(resolvers, obj, identifier, arg);\n    }\n\n    @Override\n    public Iterator<?> getIterator(Object obj) {\n      checkAccess(obj);\n      return uberspect.getIterator(obj);\n    }\n\n    @Override\n    public JexlArithmetic.Uberspect getArithmetic(JexlArithmetic arithmetic) {\n      return uberspect.getArithmetic(arithmetic);\n    } \n  }\n}\n```\n\n## References\n* Apache Commons JEXL: [Project page](https://commons.apache.org/proper/commons-jexl/).\n* Apache Commons JEXL documentation: [JEXL 2.1.1 API](https://commons.apache.org/proper/commons-jexl/javadocs/apidocs-2.1.1/).\n* Apache Commons JEXL documentation: [JEXL 3.1 API](https://commons.apache.org/proper/commons-jexl/apidocs/index.html).\n* OWASP: [Expression Language Injection](https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+                                    "markdown": "# Expression language injection (JEXL)\nJava EXpression Language (JEXL) is a simple expression language provided by the Apache Commons JEXL library. The syntax is close to a mix of ECMAScript and shell-script. The language allows invocation of methods available in the JVM. If a JEXL expression is built using attacker-controlled data, and then evaluated, then it may allow the attacker to run arbitrary code.\n\n\n## Recommendation\nIt is generally recommended to avoid using untrusted input in a JEXL expression. If it is not possible, JEXL expressions should be run in a sandbox that allows accessing only explicitly allowed classes.\n\n\n## Example\nThe following example uses untrusted data to build and run a JEXL expression.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n        new InputStreamReader(socket.getInputStream()))) {\n    \n    String input = reader.readLine();\n    JexlEngine jexl = new JexlBuilder().create();\n    JexlExpression expression = jexl.createExpression(input);\n    JexlContext context = new MapContext();\n    expression.evaluate(context);\n  }\n}\n```\nThe next example shows how an untrusted JEXL expression can be run in a sandbox that allows accessing only methods in the `java.lang.Math` class. The sandbox is implemented using `JexlSandbox` class that is provided by Apache Commons JEXL 3.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n        new InputStreamReader(socket.getInputStream()))) {\n    \n    JexlSandbox onlyMath = new JexlSandbox(false);\n    onlyMath.white(\"java.lang.Math\");\n    JexlEngine jexl = new JexlBuilder().sandbox(onlyMath).create();\n      \n    String input = reader.readLine();\n    JexlExpression expression = jexl.createExpression(input);\n    JexlContext context = new MapContext();\n    expression.evaluate(context);\n  }\n}\n```\nThe next example shows another way how a sandbox can be implemented. It uses a custom implementation of `JexlUberspect` that checks if callees are instances of allowed classes.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n        new InputStreamReader(socket.getInputStream()))) {\n    \n    JexlUberspect sandbox = new JexlUberspectSandbox();\n    JexlEngine jexl = new JexlBuilder().uberspect(sandbox).create();\n      \n    String input = reader.readLine();\n    JexlExpression expression = jexl.createExpression(input);\n    JexlContext context = new MapContext();\n    expression.evaluate(context);\n  }\n\n  private static class JexlUberspectSandbox implements JexlUberspect {\n\n    private static final List<String> ALLOWED_CLASSES =\n              Arrays.asList(\"java.lang.Math\", \"java.util.Random\");\n\n    private final JexlUberspect uberspect = new JexlBuilder().create().getUberspect();\n\n    private void checkAccess(Object obj) {\n      if (!ALLOWED_CLASSES.contains(obj.getClass().getCanonicalName())) {\n        throw new AccessControlException(\"Not allowed\");\n      }\n    }\n\n    @Override\n    public JexlMethod getMethod(Object obj, String method, Object... args) {\n      checkAccess(obj);\n      return uberspect.getMethod(obj, method, args);\n    }\n\n    @Override\n    public List<PropertyResolver> getResolvers(JexlOperator op, Object obj) {\n      checkAccess(obj);\n      return uberspect.getResolvers(op, obj);\n    }\n\n    @Override\n    public void setClassLoader(ClassLoader loader) {\n      uberspect.setClassLoader(loader);\n    }\n\n    @Override\n    public int getVersion() {\n      return uberspect.getVersion();\n    }\n\n    @Override\n    public JexlMethod getConstructor(Object obj, Object... args) {\n      checkAccess(obj);\n      return uberspect.getConstructor(obj, args);\n    }\n\n    @Override\n    public JexlPropertyGet getPropertyGet(Object obj, Object identifier) {\n      checkAccess(obj);\n      return uberspect.getPropertyGet(obj, identifier);\n    }\n\n    @Override\n    public JexlPropertyGet getPropertyGet(List<PropertyResolver> resolvers, Object obj, Object identifier) {\n      checkAccess(obj);\n      return uberspect.getPropertyGet(resolvers, obj, identifier);\n    }\n\n    @Override\n    public JexlPropertySet getPropertySet(Object obj, Object identifier, Object arg) {\n      checkAccess(obj);\n      return uberspect.getPropertySet(obj, identifier, arg);\n    }\n\n    @Override\n    public JexlPropertySet getPropertySet(List<PropertyResolver> resolvers, Object obj, Object identifier, Object arg) {\n      checkAccess(obj);\n      return uberspect.getPropertySet(resolvers, obj, identifier, arg);\n    }\n\n    @Override\n    public Iterator<?> getIterator(Object obj) {\n      checkAccess(obj);\n      return uberspect.getIterator(obj);\n    }\n\n    @Override\n    public JexlArithmetic.Uberspect getArithmetic(JexlArithmetic arithmetic) {\n      return uberspect.getArithmetic(arithmetic);\n    } \n  }\n}\n```\n\n## References\n* Apache Commons JEXL: [Project page](https://commons.apache.org/proper/commons-jexl/).\n* Apache Commons JEXL documentation: [JEXL 2.1.1 API](https://commons.apache.org/proper/commons-jexl/javadocs/apidocs-2.1.1/).\n* Apache Commons JEXL documentation: [JEXL 3.1 API](https://commons.apache.org/proper/commons-jexl/apidocs/index.html).\n* OWASP: [Expression Language Injection](https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-094"
+                                    ],
+                                    "description": "Evaluation of a user-controlled JEXL expression\n              may lead to arbitrary code execution.",
+                                    "id": "java/jexl-expression-injection",
+                                    "kind": "path-problem",
+                                    "name": "Expression language injection (JEXL)",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/mvel-expression-injection",
+                                "name": "java/mvel-expression-injection",
+                                "shortDescription": {
+                                    "text": "Expression language injection (MVEL)"
+                                },
+                                "fullDescription": {
+                                    "text": "Evaluation of a user-controlled MVEL expression may lead to remote code execution."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Expression language injection (MVEL)\nMVEL is an expression language based on Java-syntax, which offers many features including invocation of methods available in the JVM. If a MVEL expression is built using attacker-controlled data, and then evaluated, then it may allow attackers to run arbitrary code.\n\n\n## Recommendation\nIncluding user input in a MVEL expression should be avoided.\n\n\n## Example\nIn the following sample, the first example uses untrusted data to build a MVEL expression and then runs it in the default context. In the second example, the untrusted data is validated with a custom method that checks that the expression does not contain unexpected code before evaluating it.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n    new InputStreamReader(socket.getInputStream()))) {\n  \n    String expression = reader.readLine();\n    // BAD: the user-provided expression is directly evaluated\n    MVEL.eval(expression);\n  }\n}\n\npublic void safeEvaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n    new InputStreamReader(socket.getInputStream()))) {\n  \n    String expression = reader.readLine();\n    // GOOD: the user-provided expression is validated before evaluation\n    validateExpression(expression);\n    MVEL.eval(expression);\n  }\n}\n\nprivate void validateExpression(String expression) {\n  // Validate that the expression does not contain unexpected code.\n  // For instance, this can be done with allow-lists or deny-lists of code patterns.\n}\n```\n\n## References\n* MVEL Documentation: [Language Guide for 2.0](http://mvel.documentnode.com/).\n* OWASP: [Expression Language Injection](https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+                                    "markdown": "# Expression language injection (MVEL)\nMVEL is an expression language based on Java-syntax, which offers many features including invocation of methods available in the JVM. If a MVEL expression is built using attacker-controlled data, and then evaluated, then it may allow attackers to run arbitrary code.\n\n\n## Recommendation\nIncluding user input in a MVEL expression should be avoided.\n\n\n## Example\nIn the following sample, the first example uses untrusted data to build a MVEL expression and then runs it in the default context. In the second example, the untrusted data is validated with a custom method that checks that the expression does not contain unexpected code before evaluating it.\n\n\n```java\npublic void evaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n    new InputStreamReader(socket.getInputStream()))) {\n  \n    String expression = reader.readLine();\n    // BAD: the user-provided expression is directly evaluated\n    MVEL.eval(expression);\n  }\n}\n\npublic void safeEvaluate(Socket socket) throws IOException {\n  try (BufferedReader reader = new BufferedReader(\n    new InputStreamReader(socket.getInputStream()))) {\n  \n    String expression = reader.readLine();\n    // GOOD: the user-provided expression is validated before evaluation\n    validateExpression(expression);\n    MVEL.eval(expression);\n  }\n}\n\nprivate void validateExpression(String expression) {\n  // Validate that the expression does not contain unexpected code.\n  // For instance, this can be done with allow-lists or deny-lists of code patterns.\n}\n```\n\n## References\n* MVEL Documentation: [Language Guide for 2.0](http://mvel.documentnode.com/).\n* OWASP: [Expression Language Injection](https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-094"
+                                    ],
+                                    "description": "Evaluation of a user-controlled MVEL expression\n              may lead to remote code execution.",
+                                    "id": "java/mvel-expression-injection",
+                                    "kind": "path-problem",
+                                    "name": "Expression language injection (MVEL)",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/groovy-injection",
+                                "name": "java/groovy-injection",
+                                "shortDescription": {
+                                    "text": "Groovy Language injection"
+                                },
+                                "fullDescription": {
+                                    "text": "Evaluation of a user-controlled Groovy script may lead to arbitrary code execution."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Groovy Language injection\nApache Groovy is a powerful, optionally typed and dynamic language, with static-typing and static compilation capabilities. It integrates smoothly with any Java program, and immediately delivers to your application powerful features, including scripting capabilities, Domain-Specific Language authoring, runtime and compile-time meta-programming and functional programming. If a Groovy script is built using attacker-controlled data, and then evaluated, then it may allow the attacker to achieve RCE.\n\n\n## Recommendation\nIt is generally recommended to avoid using untrusted input in a Groovy evaluation. If this is not possible, use a sandbox solution. Developers must also take care that Groovy compile-time metaprogramming can also lead to RCE: it is possible to achieve RCE by compiling a Groovy script (see the article \"Abusing Meta Programming for Unauthenticated RCE!\" linked below). Groovy's `SecureASTCustomizer` allows securing source code by controlling what code constructs are permitted. This is typically done when using Groovy for its scripting or domain specific language (DSL) features. The fundamental problem is that Groovy is a dynamic language, yet `SecureASTCustomizer` works by looking at Groovy AST statically. This makes it very easy for an attacker to bypass many of the intended checks (see \\[Groovy SecureASTCustomizer is harmful\\](https://kohsuke.org/2012/04/27/groovy-secureastcustomizer-is-harmful/)). Therefore, besides `SecureASTCustomizer`, runtime checks are also necessary before calling Groovy methods (see \\[Improved sandboxing of Groovy scripts\\](https://melix.github.io/blog/2015/03/sandboxing.html)). It is also possible to use a block-list method, excluding unwanted classes from being loaded by the JVM. This method is not always recommended, because block-lists can be bypassed by unexpected values.\n\n\n## Example\nThe following example uses untrusted data to evaluate a Groovy script.\n\n\n```java\npublic class GroovyInjection {\n    void injectionViaClassLoader(HttpServletRequest request) {    \n        String script = request.getParameter(\"script\");\n        final GroovyClassLoader classLoader = new GroovyClassLoader();\n        Class groovy = classLoader.parseClass(script);\n        GroovyObject groovyObj = (GroovyObject) groovy.newInstance();\n    }\n\n    void injectionViaEval(HttpServletRequest request) {\n        String script = request.getParameter(\"script\");\n        Eval.me(script);\n    }\n\n    void injectionViaGroovyShell(HttpServletRequest request) {\n        GroovyShell shell = new GroovyShell();\n        String script = request.getParameter(\"script\");\n        shell.evaluate(script);\n    }\n\n    void injectionViaGroovyShellGroovyCodeSource(HttpServletRequest request) {\n        GroovyShell shell = new GroovyShell();\n        String script = request.getParameter(\"script\");\n        GroovyCodeSource gcs = new GroovyCodeSource(script, \"test\", \"Test\");\n        shell.evaluate(gcs);\n    }\n}\n\n\n```\nThe following example uses classloader block-list approach to exclude loading dangerous classes.\n\n\n```java\npublic class SandboxGroovyClassLoader extends ClassLoader {\n    public SandboxGroovyClassLoader(ClassLoader parent) {\n        super(parent);\n    }\n\n    /* override `loadClass` here to prevent loading sensitive classes, such as `java.lang.Runtime`, `java.lang.ProcessBuilder`, `java.lang.System`, etc.  */\n    /* Note we must also block `groovy.transform.ASTTest`, `groovy.lang.GrabConfig` and `org.buildobjects.process.ProcBuilder` to prevent compile-time RCE. */\n\n    static void runWithSandboxGroovyClassLoader() throws Exception {\n        // GOOD: route all class-loading via sand-boxing classloader.\n        SandboxGroovyClassLoader classLoader = new GroovyClassLoader(new SandboxGroovyClassLoader());\n        \n        Class<?> scriptClass = classLoader.parseClass(untrusted.getQueryString());\n        Object scriptInstance = scriptClass.newInstance();\n        Object result = scriptClass.getDeclaredMethod(\"bar\", new Class[]{}).invoke(scriptInstance, new Object[]{});\n    }\n}\n```\n\n## References\n* Orange Tsai: [Abusing Meta Programming for Unauthenticated RCE!](https://blog.orange.tw/2019/02/abusing-meta-programming-for-unauthenticated-rce.html).\n* Cédric Champeau: [Improved sandboxing of Groovy scripts](https://melix.github.io/blog/2015/03/sandboxing.html).\n* Kohsuke Kawaguchi: [Groovy SecureASTCustomizer is harmful](https://kohsuke.org/2012/04/27/groovy-secureastcustomizer-is-harmful/).\n* Welk1n: [Groovy Injection payloads](https://github.com/welk1n/exploiting-groovy-in-Java/).\n* Charles Chan: [Secure Groovy Script Execution in a Sandbox](https://levelup.gitconnected.com/secure-groovy-script-execution-in-a-sandbox-ea39f80ee87/).\n* Eugene: [Scripting and sandboxing in a JVM environment](https://stringconcat.com/en/scripting-and-sandboxing/).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+                                    "markdown": "# Groovy Language injection\nApache Groovy is a powerful, optionally typed and dynamic language, with static-typing and static compilation capabilities. It integrates smoothly with any Java program, and immediately delivers to your application powerful features, including scripting capabilities, Domain-Specific Language authoring, runtime and compile-time meta-programming and functional programming. If a Groovy script is built using attacker-controlled data, and then evaluated, then it may allow the attacker to achieve RCE.\n\n\n## Recommendation\nIt is generally recommended to avoid using untrusted input in a Groovy evaluation. If this is not possible, use a sandbox solution. Developers must also take care that Groovy compile-time metaprogramming can also lead to RCE: it is possible to achieve RCE by compiling a Groovy script (see the article \"Abusing Meta Programming for Unauthenticated RCE!\" linked below). Groovy's `SecureASTCustomizer` allows securing source code by controlling what code constructs are permitted. This is typically done when using Groovy for its scripting or domain specific language (DSL) features. The fundamental problem is that Groovy is a dynamic language, yet `SecureASTCustomizer` works by looking at Groovy AST statically. This makes it very easy for an attacker to bypass many of the intended checks (see \\[Groovy SecureASTCustomizer is harmful\\](https://kohsuke.org/2012/04/27/groovy-secureastcustomizer-is-harmful/)). Therefore, besides `SecureASTCustomizer`, runtime checks are also necessary before calling Groovy methods (see \\[Improved sandboxing of Groovy scripts\\](https://melix.github.io/blog/2015/03/sandboxing.html)). It is also possible to use a block-list method, excluding unwanted classes from being loaded by the JVM. This method is not always recommended, because block-lists can be bypassed by unexpected values.\n\n\n## Example\nThe following example uses untrusted data to evaluate a Groovy script.\n\n\n```java\npublic class GroovyInjection {\n    void injectionViaClassLoader(HttpServletRequest request) {    \n        String script = request.getParameter(\"script\");\n        final GroovyClassLoader classLoader = new GroovyClassLoader();\n        Class groovy = classLoader.parseClass(script);\n        GroovyObject groovyObj = (GroovyObject) groovy.newInstance();\n    }\n\n    void injectionViaEval(HttpServletRequest request) {\n        String script = request.getParameter(\"script\");\n        Eval.me(script);\n    }\n\n    void injectionViaGroovyShell(HttpServletRequest request) {\n        GroovyShell shell = new GroovyShell();\n        String script = request.getParameter(\"script\");\n        shell.evaluate(script);\n    }\n\n    void injectionViaGroovyShellGroovyCodeSource(HttpServletRequest request) {\n        GroovyShell shell = new GroovyShell();\n        String script = request.getParameter(\"script\");\n        GroovyCodeSource gcs = new GroovyCodeSource(script, \"test\", \"Test\");\n        shell.evaluate(gcs);\n    }\n}\n\n\n```\nThe following example uses classloader block-list approach to exclude loading dangerous classes.\n\n\n```java\npublic class SandboxGroovyClassLoader extends ClassLoader {\n    public SandboxGroovyClassLoader(ClassLoader parent) {\n        super(parent);\n    }\n\n    /* override `loadClass` here to prevent loading sensitive classes, such as `java.lang.Runtime`, `java.lang.ProcessBuilder`, `java.lang.System`, etc.  */\n    /* Note we must also block `groovy.transform.ASTTest`, `groovy.lang.GrabConfig` and `org.buildobjects.process.ProcBuilder` to prevent compile-time RCE. */\n\n    static void runWithSandboxGroovyClassLoader() throws Exception {\n        // GOOD: route all class-loading via sand-boxing classloader.\n        SandboxGroovyClassLoader classLoader = new GroovyClassLoader(new SandboxGroovyClassLoader());\n        \n        Class<?> scriptClass = classLoader.parseClass(untrusted.getQueryString());\n        Object scriptInstance = scriptClass.newInstance();\n        Object result = scriptClass.getDeclaredMethod(\"bar\", new Class[]{}).invoke(scriptInstance, new Object[]{});\n    }\n}\n```\n\n## References\n* Orange Tsai: [Abusing Meta Programming for Unauthenticated RCE!](https://blog.orange.tw/2019/02/abusing-meta-programming-for-unauthenticated-rce.html).\n* Cédric Champeau: [Improved sandboxing of Groovy scripts](https://melix.github.io/blog/2015/03/sandboxing.html).\n* Kohsuke Kawaguchi: [Groovy SecureASTCustomizer is harmful](https://kohsuke.org/2012/04/27/groovy-secureastcustomizer-is-harmful/).\n* Welk1n: [Groovy Injection payloads](https://github.com/welk1n/exploiting-groovy-in-Java/).\n* Charles Chan: [Secure Groovy Script Execution in a Sandbox](https://levelup.gitconnected.com/secure-groovy-script-execution-in-a-sandbox-ea39f80ee87/).\n* Eugene: [Scripting and sandboxing in a JVM environment](https://stringconcat.com/en/scripting-and-sandboxing/).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-094"
+                                    ],
+                                    "description": "Evaluation of a user-controlled Groovy script\n              may lead to arbitrary code execution.",
+                                    "id": "java/groovy-injection",
+                                    "kind": "path-problem",
+                                    "name": "Groovy Language injection",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/insecure-bean-validation",
+                                "name": "java/insecure-bean-validation",
+                                "shortDescription": {
+                                    "text": "Insecure Bean Validation"
+                                },
+                                "fullDescription": {
+                                    "text": "User-controlled data may be evaluated as a Java EL expression, leading to arbitrary code execution."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Insecure Bean Validation\nCustom error messages for constraint validators support different types of interpolation, including [Java EL expressions](https://docs.jboss.org/hibernate/validator/5.1/reference/en-US/html/chapter-message-interpolation.html#section-interpolation-with-message-expressions). Controlling part of the message template being passed to `ConstraintValidatorContext.buildConstraintViolationWithTemplate()` argument can lead to arbitrary Java code execution. Unfortunately, it is common that validated (and therefore, normally untrusted) bean properties flow into the custom error message.\n\n\n## Recommendation\nThere are different approaches to remediate the issue:\n\n* Do not include validated bean properties in the custom error message.\n* Use parameterized messages instead of string concatenation. For example:\n```\nHibernateConstraintValidatorContext context =\n   constraintValidatorContext.unwrap(HibernateConstraintValidatorContext.class);\ncontext.addMessageParameter(\"foo\", \"bar\");\ncontext.buildConstraintViolationWithTemplate(\"My violation message contains a parameter {foo}\")\n   .addConstraintViolation();\n```\n* Sanitize the validated bean properties to make sure that there are no EL expressions. An example of valid sanitization logic can be found [here](https://github.com/hibernate/hibernate-validator/blob/master/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/util/InterpolationHelper.java#L17).\n* Disable the EL interpolation and only use `ParameterMessageInterpolator`:\n```\nValidator validator = Validation.byDefaultProvider()\n   .configure()\n   .messageInterpolator(new ParameterMessageInterpolator())\n   .buildValidatorFactory()\n   .getValidator();\n```\n* Replace Hibernate Validator with Apache BVal, which in its latest version does not interpolate EL expressions by default. Note that this replacement may not be a simple drop-in replacement.\n\n## Example\nThe following validator could result in arbitrary Java code execution:\n\n\n```java\nimport javax.validation.ConstraintValidator;\nimport javax.validation.ConstraintValidatorContext;\nimport org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;\nimport java.util.regex.Matcher;\nimport java.util.regex.Pattern;\n\npublic class TestValidator implements ConstraintValidator<Object, String> {\n\n    public static class InterpolationHelper {\n\n        public static final char BEGIN_TERM = '{';\n        public static final char END_TERM = '}';\n        public static final char EL_DESIGNATOR = '$';\n        public static final char ESCAPE_CHARACTER = '\\\\';\n\n        private static final Pattern ESCAPE_MESSAGE_PARAMETER_PATTERN = Pattern.compile( \"([\\\\\" + ESCAPE_CHARACTER + BEGIN_TERM + END_TERM + EL_DESIGNATOR + \"])\" );\n\n        private InterpolationHelper() {\n        }\n\n        public static String escapeMessageParameter(String messageParameter) {\n            if ( messageParameter == null ) {\n                return null;\n            }\n            return ESCAPE_MESSAGE_PARAMETER_PATTERN.matcher( messageParameter ).replaceAll( Matcher.quoteReplacement( String.valueOf( ESCAPE_CHARACTER ) ) + \"$1\" );\n        }\n\n    }\n\n    @Override\n    public boolean isValid(String object, ConstraintValidatorContext constraintContext) {\n        String value = object + \" is invalid\";\n\n        // Bad: Bean properties (normally user-controlled) are passed directly to `buildConstraintViolationWithTemplate`\n        constraintContext.buildConstraintViolationWithTemplate(value).addConstraintViolation().disableDefaultConstraintViolation();\n\n        // Good: Bean properties (normally user-controlled) are escaped \n        String escaped = InterpolationHelper.escapeMessageParameter(value);\n        constraintContext.buildConstraintViolationWithTemplate(escaped).addConstraintViolation().disableDefaultConstraintViolation();\n\n        // Good: Bean properties (normally user-controlled) are parameterized\n        HibernateConstraintValidatorContext context = constraintContext.unwrap( HibernateConstraintValidatorContext.class );\n        context.addMessageParameter( \"prop\", object );\n        context.buildConstraintViolationWithTemplate( \"{prop} is invalid\").addConstraintViolation();\n        return false;\n    }\n\n}\n\n```\n\n## References\n* Hibernate Reference Guide: [ConstraintValidatorContext](https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#_the_code_constraintvalidatorcontext_code).\n* GitHub Security Lab research: [Bean validation](https://securitylab.github.com/research/bean-validation-RCE).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n",
+                                    "markdown": "# Insecure Bean Validation\nCustom error messages for constraint validators support different types of interpolation, including [Java EL expressions](https://docs.jboss.org/hibernate/validator/5.1/reference/en-US/html/chapter-message-interpolation.html#section-interpolation-with-message-expressions). Controlling part of the message template being passed to `ConstraintValidatorContext.buildConstraintViolationWithTemplate()` argument can lead to arbitrary Java code execution. Unfortunately, it is common that validated (and therefore, normally untrusted) bean properties flow into the custom error message.\n\n\n## Recommendation\nThere are different approaches to remediate the issue:\n\n* Do not include validated bean properties in the custom error message.\n* Use parameterized messages instead of string concatenation. For example:\n```\nHibernateConstraintValidatorContext context =\n   constraintValidatorContext.unwrap(HibernateConstraintValidatorContext.class);\ncontext.addMessageParameter(\"foo\", \"bar\");\ncontext.buildConstraintViolationWithTemplate(\"My violation message contains a parameter {foo}\")\n   .addConstraintViolation();\n```\n* Sanitize the validated bean properties to make sure that there are no EL expressions. An example of valid sanitization logic can be found [here](https://github.com/hibernate/hibernate-validator/blob/master/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/util/InterpolationHelper.java#L17).\n* Disable the EL interpolation and only use `ParameterMessageInterpolator`:\n```\nValidator validator = Validation.byDefaultProvider()\n   .configure()\n   .messageInterpolator(new ParameterMessageInterpolator())\n   .buildValidatorFactory()\n   .getValidator();\n```\n* Replace Hibernate Validator with Apache BVal, which in its latest version does not interpolate EL expressions by default. Note that this replacement may not be a simple drop-in replacement.\n\n## Example\nThe following validator could result in arbitrary Java code execution:\n\n\n```java\nimport javax.validation.ConstraintValidator;\nimport javax.validation.ConstraintValidatorContext;\nimport org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;\nimport java.util.regex.Matcher;\nimport java.util.regex.Pattern;\n\npublic class TestValidator implements ConstraintValidator<Object, String> {\n\n    public static class InterpolationHelper {\n\n        public static final char BEGIN_TERM = '{';\n        public static final char END_TERM = '}';\n        public static final char EL_DESIGNATOR = '$';\n        public static final char ESCAPE_CHARACTER = '\\\\';\n\n        private static final Pattern ESCAPE_MESSAGE_PARAMETER_PATTERN = Pattern.compile( \"([\\\\\" + ESCAPE_CHARACTER + BEGIN_TERM + END_TERM + EL_DESIGNATOR + \"])\" );\n\n        private InterpolationHelper() {\n        }\n\n        public static String escapeMessageParameter(String messageParameter) {\n            if ( messageParameter == null ) {\n                return null;\n            }\n            return ESCAPE_MESSAGE_PARAMETER_PATTERN.matcher( messageParameter ).replaceAll( Matcher.quoteReplacement( String.valueOf( ESCAPE_CHARACTER ) ) + \"$1\" );\n        }\n\n    }\n\n    @Override\n    public boolean isValid(String object, ConstraintValidatorContext constraintContext) {\n        String value = object + \" is invalid\";\n\n        // Bad: Bean properties (normally user-controlled) are passed directly to `buildConstraintViolationWithTemplate`\n        constraintContext.buildConstraintViolationWithTemplate(value).addConstraintViolation().disableDefaultConstraintViolation();\n\n        // Good: Bean properties (normally user-controlled) are escaped \n        String escaped = InterpolationHelper.escapeMessageParameter(value);\n        constraintContext.buildConstraintViolationWithTemplate(escaped).addConstraintViolation().disableDefaultConstraintViolation();\n\n        // Good: Bean properties (normally user-controlled) are parameterized\n        HibernateConstraintValidatorContext context = constraintContext.unwrap( HibernateConstraintValidatorContext.class );\n        context.addMessageParameter( \"prop\", object );\n        context.buildConstraintViolationWithTemplate( \"{prop} is invalid\").addConstraintViolation();\n        return false;\n    }\n\n}\n\n```\n\n## References\n* Hibernate Reference Guide: [ConstraintValidatorContext](https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#_the_code_constraintvalidatorcontext_code).\n* GitHub Security Lab research: [Bean validation](https://securitylab.github.com/research/bean-validation-RCE).\n* Common Weakness Enumeration: [CWE-94](https://cwe.mitre.org/data/definitions/94.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-094"
+                                    ],
+                                    "description": "User-controlled data may be evaluated as a Java EL expression, leading to arbitrary code execution.",
+                                    "id": "java/insecure-bean-validation",
+                                    "kind": "path-problem",
+                                    "name": "Insecure Bean Validation",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/unvalidated-url-redirection",
+                                "name": "java/unvalidated-url-redirection",
+                                "shortDescription": {
+                                    "text": "URL redirection from remote source"
+                                },
+                                "fullDescription": {
+                                    "text": "URL redirection based on unvalidated user-input may cause redirection to malicious web sites."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# URL redirection from remote source\nDirectly incorporating user input into a URL redirect request without validating the input can facilitate phishing attacks. In these attacks, unsuspecting users can be redirected to a malicious site that looks very similar to the real site they intend to visit, but which is controlled by the attacker.\n\n\n## Recommendation\nTo guard against untrusted URL redirection, it is advisable to avoid putting user input directly into a redirect URL. Instead, maintain a list of authorized redirects on the server; then choose from that list based on the user input provided.\n\n\n## Example\nThe following example shows an HTTP request parameter being used directly in a URL redirect without validating the input, which facilitates phishing attacks. It also shows how to remedy the problem by validating the user input against a known fixed string.\n\n\n```java\npublic class UrlRedirect extends HttpServlet {\n\tprivate static final String VALID_REDIRECT = \"http://cwe.mitre.org/data/definitions/601.html\";\n\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: a request parameter is incorporated without validation into a URL redirect\n\t\tresponse.sendRedirect(request.getParameter(\"target\"));\n\n\t\t// GOOD: the request parameter is validated against a known fixed string\n\t\tif (VALID_REDIRECT.equals(request.getParameter(\"target\"))) {\n\t\t\tresponse.sendRedirect(VALID_REDIRECT);\n\t\t}\n\t}\n}\n\n```\n\n## References\n* Common Weakness Enumeration: [CWE-601](https://cwe.mitre.org/data/definitions/601.html).\n",
+                                    "markdown": "# URL redirection from remote source\nDirectly incorporating user input into a URL redirect request without validating the input can facilitate phishing attacks. In these attacks, unsuspecting users can be redirected to a malicious site that looks very similar to the real site they intend to visit, but which is controlled by the attacker.\n\n\n## Recommendation\nTo guard against untrusted URL redirection, it is advisable to avoid putting user input directly into a redirect URL. Instead, maintain a list of authorized redirects on the server; then choose from that list based on the user input provided.\n\n\n## Example\nThe following example shows an HTTP request parameter being used directly in a URL redirect without validating the input, which facilitates phishing attacks. It also shows how to remedy the problem by validating the user input against a known fixed string.\n\n\n```java\npublic class UrlRedirect extends HttpServlet {\n\tprivate static final String VALID_REDIRECT = \"http://cwe.mitre.org/data/definitions/601.html\";\n\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: a request parameter is incorporated without validation into a URL redirect\n\t\tresponse.sendRedirect(request.getParameter(\"target\"));\n\n\t\t// GOOD: the request parameter is validated against a known fixed string\n\t\tif (VALID_REDIRECT.equals(request.getParameter(\"target\"))) {\n\t\t\tresponse.sendRedirect(VALID_REDIRECT);\n\t\t}\n\t}\n}\n\n```\n\n## References\n* Common Weakness Enumeration: [CWE-601](https://cwe.mitre.org/data/definitions/601.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-601"
+                                    ],
+                                    "description": "URL redirection based on unvalidated user-input\n              may cause redirection to malicious web sites.",
+                                    "id": "java/unvalidated-url-redirection",
+                                    "kind": "path-problem",
+                                    "name": "URL redirection from remote source",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "6.1"
+                                }
+                            },
+                            {
+                                "id": "java/unsafe-hostname-verification",
+                                "name": "java/unsafe-hostname-verification",
+                                "shortDescription": {
+                                    "text": "Unsafe hostname verification"
+                                },
+                                "fullDescription": {
+                                    "text": "Marking a certificate as valid for a host without checking the certificate hostname allows an attacker to perform a machine-in-the-middle attack."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Unsafe hostname verification\nIf a `HostnameVerifier` always returns `true` it will not verify the hostname at all. This stops Transport Layer Security (TLS) providing any security and allows an attacker to perform a man-in-the-middle attack against the application.\n\nAn attack might look like this:\n\n1. The program connects to `https://example.com`.\n1. The attacker intercepts this connection and presents an apparently-valid certificate of their choosing.\n1. The `TrustManager` of the program verifies that the certificate has been issued by a trusted certificate authority.\n1. The Java HTTPS library checks whether the certificate has been issued for the host `example.com`. This check fails because the certificate has been issued for a domain controlled by the attacker, for example: `malicious.domain`.\n1. The HTTPS library wants to reject the certificate because the hostname does not match. Before doing this it checks whether a `HostnameVerifier` exists.\n1. Your `HostnameVerifier` is called which returns `true` for any certificate so also for this one.\n1. The program proceeds with the connection since your `HostnameVerifier` accepted it.\n1. The attacker can now read the data your program sends to `https://example.com` and/or alter its replies while the program thinks the connection is secure.\n\n## Recommendation\nDo not use an open `HostnameVerifier`. If you have a configuration problem with TLS/HTTPS, you should always solve the configuration problem instead of using an open verifier.\n\n\n## Example\nIn the first (bad) example, the `HostnameVerifier` always returns `true`. This allows an attacker to perform a man-in-the-middle attack, because any certificate is accepted despite an incorrect hostname. In the second (good) example, the `HostnameVerifier` only returns `true` when the certificate has been correctly checked.\n\n\n```java\npublic static void main(String[] args) {\n\n\t{\n\t\tHostnameVerifier verifier = new HostnameVerifier() {\n\t\t\t@Override\n\t\t\tpublic boolean verify(String hostname, SSLSession session) {\n\t\t\t\treturn true; // BAD: accept even if the hostname doesn't match\n\t\t\t}\n\t\t};\n\t\tHttpsURLConnection.setDefaultHostnameVerifier(verifier);\n\t}\n\n\t{\n\t\tHostnameVerifier verifier = new HostnameVerifier() {\n\t\t\t@Override\n\t\t\tpublic boolean verify(String hostname, SSLSession session) {\n\t\t\t\ttry { // GOOD: verify the certificate\n\t\t\t\t\tCertificate[] certs = session.getPeerCertificates();\n\t\t\t\t\tX509Certificate x509 = (X509Certificate) certs[0];\n\t\t\t\t\tcheck(new String[]{host}, x509);\n\t\t\t\t\treturn true;\n\t\t\t\t} catch (SSLException e) {\n\t\t\t\t\treturn false;\n\t\t\t\t}\n\t\t\t}\n\t\t};\n\t\tHttpsURLConnection.setDefaultHostnameVerifier(verifier);\n\t}\n\n}\n```\n\n## References\n* Android developers: [Security with HTTPS and SSL](https://developer.android.com/training/articles/security-ssl).\n* Terse systems blog: [Fixing Hostname Verification](https://tersesystems.com/blog/2014/03/23/fixing-hostname-verification/).\n* Common Weakness Enumeration: [CWE-297](https://cwe.mitre.org/data/definitions/297.html).\n",
+                                    "markdown": "# Unsafe hostname verification\nIf a `HostnameVerifier` always returns `true` it will not verify the hostname at all. This stops Transport Layer Security (TLS) providing any security and allows an attacker to perform a man-in-the-middle attack against the application.\n\nAn attack might look like this:\n\n1. The program connects to `https://example.com`.\n1. The attacker intercepts this connection and presents an apparently-valid certificate of their choosing.\n1. The `TrustManager` of the program verifies that the certificate has been issued by a trusted certificate authority.\n1. The Java HTTPS library checks whether the certificate has been issued for the host `example.com`. This check fails because the certificate has been issued for a domain controlled by the attacker, for example: `malicious.domain`.\n1. The HTTPS library wants to reject the certificate because the hostname does not match. Before doing this it checks whether a `HostnameVerifier` exists.\n1. Your `HostnameVerifier` is called which returns `true` for any certificate so also for this one.\n1. The program proceeds with the connection since your `HostnameVerifier` accepted it.\n1. The attacker can now read the data your program sends to `https://example.com` and/or alter its replies while the program thinks the connection is secure.\n\n## Recommendation\nDo not use an open `HostnameVerifier`. If you have a configuration problem with TLS/HTTPS, you should always solve the configuration problem instead of using an open verifier.\n\n\n## Example\nIn the first (bad) example, the `HostnameVerifier` always returns `true`. This allows an attacker to perform a man-in-the-middle attack, because any certificate is accepted despite an incorrect hostname. In the second (good) example, the `HostnameVerifier` only returns `true` when the certificate has been correctly checked.\n\n\n```java\npublic static void main(String[] args) {\n\n\t{\n\t\tHostnameVerifier verifier = new HostnameVerifier() {\n\t\t\t@Override\n\t\t\tpublic boolean verify(String hostname, SSLSession session) {\n\t\t\t\treturn true; // BAD: accept even if the hostname doesn't match\n\t\t\t}\n\t\t};\n\t\tHttpsURLConnection.setDefaultHostnameVerifier(verifier);\n\t}\n\n\t{\n\t\tHostnameVerifier verifier = new HostnameVerifier() {\n\t\t\t@Override\n\t\t\tpublic boolean verify(String hostname, SSLSession session) {\n\t\t\t\ttry { // GOOD: verify the certificate\n\t\t\t\t\tCertificate[] certs = session.getPeerCertificates();\n\t\t\t\t\tX509Certificate x509 = (X509Certificate) certs[0];\n\t\t\t\t\tcheck(new String[]{host}, x509);\n\t\t\t\t\treturn true;\n\t\t\t\t} catch (SSLException e) {\n\t\t\t\t\treturn false;\n\t\t\t\t}\n\t\t\t}\n\t\t};\n\t\tHttpsURLConnection.setDefaultHostnameVerifier(verifier);\n\t}\n\n}\n```\n\n## References\n* Android developers: [Security with HTTPS and SSL](https://developer.android.com/training/articles/security-ssl).\n* Terse systems blog: [Fixing Hostname Verification](https://tersesystems.com/blog/2014/03/23/fixing-hostname-verification/).\n* Common Weakness Enumeration: [CWE-297](https://cwe.mitre.org/data/definitions/297.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-297"
+                                    ],
+                                    "description": "Marking a certificate as valid for a host without checking the certificate hostname allows an attacker to perform a machine-in-the-middle attack.",
+                                    "id": "java/unsafe-hostname-verification",
+                                    "kind": "path-problem",
+                                    "name": "Unsafe hostname verification",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "5.9"
+                                }
+                            },
+                            {
+                                "id": "java/jhipster-prng",
+                                "name": "java/jhipster-prng",
+                                "shortDescription": {
+                                    "text": "Detect JHipster Generator Vulnerability CVE-2019-16303"
+                                },
+                                "fullDescription": {
+                                    "text": "Using a vulnerable version of JHipster to generate random numbers makes it easier for attackers to take over accounts."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Detect JHipster Generator Vulnerability CVE-2019-16303\nThis query detects instances of `RandomUtil.java` that were generated by a [JHipster](https://www.jhipster.tech/) version that is vulnerable to [CVE-2019-16303](https://github.com/jhipster/jhipster-kotlin/security/advisories/GHSA-j3rh-8vwq-wh84).\n\nIf an app uses `RandomUtil.java` generated by a vulnerable version of JHipster, attackers can request a password reset token and use this to predict the value of future reset tokens generated by this server. Using this information, they can create a reset link that allows them to take over any account.\n\nThis vulnerability has a [ CVSS v3.0 Base Score of 9.8/10 ](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2019-16303&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1&source=NIST).\n\n\n## Example\nThe example below shows the vulnerable `RandomUtil` class generated by [JHipster prior to version 6.3.0](https://www.jhipster.tech/2019/09/13/jhipster-release-6.3.0.html).\n\n\n```java\nimport org.apache.commons.lang3.RandomStringUtils;\n\n/**\n * Utility class for generating random Strings.\n */\npublic final class RandomUtil {\n\n    private static final int DEF_COUNT = 20;\n\n    private RandomUtil() {\n    }\n\n    /**\n     * Generate a password.\n     *\n     * @return the generated password.\n     */\n    public static String generatePassword() {\n        return RandomStringUtils.randomAlphanumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate an activation key.\n     *\n     * @return the generated activation key.\n     */\n    public static String generateActivationKey() {\n        return RandomStringUtils.randomNumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate a reset key.\n     *\n     * @return the generated reset key.\n     */\n    public static String generateResetKey() {\n        return RandomStringUtils.randomNumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate a unique series to validate a persistent token, used in the\n     * authentication remember-me mechanism.\n     *\n     * @return the generated series data.\n     */\n    public static String generateSeriesData() {\n        return RandomStringUtils.randomAlphanumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate a persistent token, used in the authentication remember-me mechanism.\n     *\n     * @return the generated token data.\n     */\n    public static String generateTokenData() {\n        return RandomStringUtils.randomAlphanumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n}\n\n```\nBelow is a fixed version of the `RandomUtil` class.\n\n\n```java\nimport org.apache.commons.lang3.RandomStringUtils;\n\nimport java.security.SecureRandom;\n\n/**\n * Utility class for generating random Strings.\n */\npublic final class RandomUtil {\n    private static final SecureRandom SECURE_RANDOM = new SecureRandom(); // GOOD: Using SecureRandom\n\n    private static final int DEF_COUNT = 20;\n\n    static {\n        SECURE_RANDOM.nextBytes(new byte[64]);\n    }\n\n    private RandomUtil() {\n    }\n\n    private static String generateRandomAlphanumericString() {\n        // GOOD: Passing Secure Random to RandomStringUtils::random\n        return RandomStringUtils.random(DEF_COUNT, 0, 0, true, true, null, SECURE_RANDOM);\n    }\n\n    /**\n     * Generate a password.\n     *\n     * @return the generated password.\n     */\n    public static String generatePassword() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate an activation key.\n     *\n     * @return the generated activation key.\n     */\n    public static String generateActivationKey() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate a reset key.\n     *\n     * @return the generated reset key.\n     */\n    public static String generateResetKey() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate a unique series to validate a persistent token, used in the\n     * authentication remember-me mechanism.\n     *\n     * @return the generated series data.\n     */\n    public static String generateSeriesData() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate a persistent token, used in the authentication remember-me mechanism.\n     *\n     * @return the generated token data.\n     */\n    public static String generateTokenData() {\n        return generateRandomAlphanumericString();\n    }\n}\n\n```\n\n## Recommendation\nYou should refactor the `RandomUtil` class and replace every call to `RandomStringUtils.randomAlphaNumeric`. You could regenerate the class using the latest version of JHipster, or use an automated refactoring. For example, using the [Patching JHipster CWE-338](https://github.com/moderneinc/jhipster-cwe-338) for the [Rewrite project](https://github.com/openrewrite/rewrite).\n\n\n## References\n* Cloudflare Blog: [ Why secure systems require random numbers ](https://blog.cloudflare.com/why-randomness-matters/)\n* Hacker News: [ How I Hacked Hacker News (with arc security advisory) ](https://news.ycombinator.com/item?id=639976)\n* Posts by Pucara Information Security Team: [ The Java Soothsayer: A practical application for insecure randomness. (Includes free 0day) ](https://blog.pucarasec.com/2020/05/09/the-java-soothsayer-a-practical-application-for-insecure-randomness-includes-free-0day/)\n* Common Weakness Enumeration: [CWE-338](https://cwe.mitre.org/data/definitions/338.html).\n",
+                                    "markdown": "# Detect JHipster Generator Vulnerability CVE-2019-16303\nThis query detects instances of `RandomUtil.java` that were generated by a [JHipster](https://www.jhipster.tech/) version that is vulnerable to [CVE-2019-16303](https://github.com/jhipster/jhipster-kotlin/security/advisories/GHSA-j3rh-8vwq-wh84).\n\nIf an app uses `RandomUtil.java` generated by a vulnerable version of JHipster, attackers can request a password reset token and use this to predict the value of future reset tokens generated by this server. Using this information, they can create a reset link that allows them to take over any account.\n\nThis vulnerability has a [ CVSS v3.0 Base Score of 9.8/10 ](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2019-16303&vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1&source=NIST).\n\n\n## Example\nThe example below shows the vulnerable `RandomUtil` class generated by [JHipster prior to version 6.3.0](https://www.jhipster.tech/2019/09/13/jhipster-release-6.3.0.html).\n\n\n```java\nimport org.apache.commons.lang3.RandomStringUtils;\n\n/**\n * Utility class for generating random Strings.\n */\npublic final class RandomUtil {\n\n    private static final int DEF_COUNT = 20;\n\n    private RandomUtil() {\n    }\n\n    /**\n     * Generate a password.\n     *\n     * @return the generated password.\n     */\n    public static String generatePassword() {\n        return RandomStringUtils.randomAlphanumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate an activation key.\n     *\n     * @return the generated activation key.\n     */\n    public static String generateActivationKey() {\n        return RandomStringUtils.randomNumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate a reset key.\n     *\n     * @return the generated reset key.\n     */\n    public static String generateResetKey() {\n        return RandomStringUtils.randomNumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate a unique series to validate a persistent token, used in the\n     * authentication remember-me mechanism.\n     *\n     * @return the generated series data.\n     */\n    public static String generateSeriesData() {\n        return RandomStringUtils.randomAlphanumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n\n    /**\n     * Generate a persistent token, used in the authentication remember-me mechanism.\n     *\n     * @return the generated token data.\n     */\n    public static String generateTokenData() {\n        return RandomStringUtils.randomAlphanumeric(DEF_COUNT); // BAD: RandomStringUtils does not use SecureRandom\n    }\n}\n\n```\nBelow is a fixed version of the `RandomUtil` class.\n\n\n```java\nimport org.apache.commons.lang3.RandomStringUtils;\n\nimport java.security.SecureRandom;\n\n/**\n * Utility class for generating random Strings.\n */\npublic final class RandomUtil {\n    private static final SecureRandom SECURE_RANDOM = new SecureRandom(); // GOOD: Using SecureRandom\n\n    private static final int DEF_COUNT = 20;\n\n    static {\n        SECURE_RANDOM.nextBytes(new byte[64]);\n    }\n\n    private RandomUtil() {\n    }\n\n    private static String generateRandomAlphanumericString() {\n        // GOOD: Passing Secure Random to RandomStringUtils::random\n        return RandomStringUtils.random(DEF_COUNT, 0, 0, true, true, null, SECURE_RANDOM);\n    }\n\n    /**\n     * Generate a password.\n     *\n     * @return the generated password.\n     */\n    public static String generatePassword() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate an activation key.\n     *\n     * @return the generated activation key.\n     */\n    public static String generateActivationKey() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate a reset key.\n     *\n     * @return the generated reset key.\n     */\n    public static String generateResetKey() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate a unique series to validate a persistent token, used in the\n     * authentication remember-me mechanism.\n     *\n     * @return the generated series data.\n     */\n    public static String generateSeriesData() {\n        return generateRandomAlphanumericString();\n    }\n\n    /**\n     * Generate a persistent token, used in the authentication remember-me mechanism.\n     *\n     * @return the generated token data.\n     */\n    public static String generateTokenData() {\n        return generateRandomAlphanumericString();\n    }\n}\n\n```\n\n## Recommendation\nYou should refactor the `RandomUtil` class and replace every call to `RandomStringUtils.randomAlphaNumeric`. You could regenerate the class using the latest version of JHipster, or use an automated refactoring. For example, using the [Patching JHipster CWE-338](https://github.com/moderneinc/jhipster-cwe-338) for the [Rewrite project](https://github.com/openrewrite/rewrite).\n\n\n## References\n* Cloudflare Blog: [ Why secure systems require random numbers ](https://blog.cloudflare.com/why-randomness-matters/)\n* Hacker News: [ How I Hacked Hacker News (with arc security advisory) ](https://news.ycombinator.com/item?id=639976)\n* Posts by Pucara Information Security Team: [ The Java Soothsayer: A practical application for insecure randomness. (Includes free 0day) ](https://blog.pucarasec.com/2020/05/09/the-java-soothsayer-a-practical-application-for-insecure-randomness-includes-free-0day/)\n* Common Weakness Enumeration: [CWE-338](https://cwe.mitre.org/data/definitions/338.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-338"
+                                    ],
+                                    "description": "Using a vulnerable version of JHipster to generate random numbers makes it easier for attackers to take over accounts.",
+                                    "id": "java/jhipster-prng",
+                                    "kind": "problem",
+                                    "name": "Detect JHipster Generator Vulnerability CVE-2019-16303",
+                                    "precision": "very-high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.8"
+                                }
+                            },
+                            {
+                                "id": "java/predictable-seed",
+                                "name": "java/predictable-seed",
+                                "shortDescription": {
+                                    "text": "Use of a predictable seed in a secure random number generator"
+                                },
+                                "fullDescription": {
+                                    "text": "Using a predictable seed in a pseudo-random number generator can lead to predictability of the numbers generated by it."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Use of a predictable seed in a secure random number generator\nUsing a predictable seed in a pseudo-random number generator can lead to predictability of the numbers generated by it.\n\n\n## Recommendation\nIf the predictability of the pseudo-random number generator does not matter then consider using the faster `Random` class from `java.util`. If it is important that the pseudo-random number generator produces completely unpredictable values then either let the generator securely seed itself by not specifying a seed or specify a randomly generated, unpredictable seed.\n\n\n## Example\nIn the first example shown here, a constant value is used as a seed. Depending on the implementation of ` SecureRandom`, this could lead to the same random number being generated each time the code is executed.\n\nIn the second example shown here, the system time is used as a seed. Depending on the implementation of ` SecureRandom`, if an attacker knows what time the code was run, they could predict the generated random number.\n\nIn the third example shown here, the random number generator is allowed to generate its own seed, which it will do in a secure way.\n\n\n```java\nSecureRandom prng = new SecureRandom();\nint randomData = 0;\n\n// BAD: Using a constant value as a seed for a random number generator means all numbers it generates are predictable.\nprng.setSeed(12345L);\nrandomData = prng.next(32);\n\n// BAD: System.currentTimeMillis() returns the system time which is predictable.\nprng.setSeed(System.currentTimeMillis());\nrandomData = prng.next(32);\n\n// GOOD: SecureRandom implementations seed themselves securely by default.\nprng = new SecureRandom();\nrandomData = prng.next(32);\n\n```\n\n## References\n* Common Weakness Enumeration: [CWE-335](https://cwe.mitre.org/data/definitions/335.html).\n* Common Weakness Enumeration: [CWE-337](https://cwe.mitre.org/data/definitions/337.html).\n",
+                                    "markdown": "# Use of a predictable seed in a secure random number generator\nUsing a predictable seed in a pseudo-random number generator can lead to predictability of the numbers generated by it.\n\n\n## Recommendation\nIf the predictability of the pseudo-random number generator does not matter then consider using the faster `Random` class from `java.util`. If it is important that the pseudo-random number generator produces completely unpredictable values then either let the generator securely seed itself by not specifying a seed or specify a randomly generated, unpredictable seed.\n\n\n## Example\nIn the first example shown here, a constant value is used as a seed. Depending on the implementation of ` SecureRandom`, this could lead to the same random number being generated each time the code is executed.\n\nIn the second example shown here, the system time is used as a seed. Depending on the implementation of ` SecureRandom`, if an attacker knows what time the code was run, they could predict the generated random number.\n\nIn the third example shown here, the random number generator is allowed to generate its own seed, which it will do in a secure way.\n\n\n```java\nSecureRandom prng = new SecureRandom();\nint randomData = 0;\n\n// BAD: Using a constant value as a seed for a random number generator means all numbers it generates are predictable.\nprng.setSeed(12345L);\nrandomData = prng.next(32);\n\n// BAD: System.currentTimeMillis() returns the system time which is predictable.\nprng.setSeed(System.currentTimeMillis());\nrandomData = prng.next(32);\n\n// GOOD: SecureRandom implementations seed themselves securely by default.\nprng = new SecureRandom();\nrandomData = prng.next(32);\n\n```\n\n## References\n* Common Weakness Enumeration: [CWE-335](https://cwe.mitre.org/data/definitions/335.html).\n* Common Weakness Enumeration: [CWE-337](https://cwe.mitre.org/data/definitions/337.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-335",
+                                        "external/cwe/cwe-337"
+                                    ],
+                                    "description": "Using a predictable seed in a pseudo-random number generator can lead to predictability of the numbers generated by it.",
+                                    "id": "java/predictable-seed",
+                                    "kind": "problem",
+                                    "name": "Use of a predictable seed in a secure random number generator",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/maven/dependency-upon-bintray",
+                                "name": "java/maven/dependency-upon-bintray",
+                                "shortDescription": {
+                                    "text": "Depending upon JCenter/Bintray as an artifact repository"
+                                },
+                                "fullDescription": {
+                                    "text": "Using a deprecated artifact repository may eventually give attackers access for a supply chain attack."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Depending upon JCenter/Bintray as an artifact repository\n[Bintray and JCenter are shutting down on February 1st, 2022](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). Relying upon repositories that are deprecated or scheduled to be shutdown can have unintended consequences; for example, artifacts being resolved from a different artifact server or a total failure of the CI build.\n\nWhen artifact repositories are left unmaintained for a long period of time, vulnerabilities may emerge. Theoretically, this could allow attackers to inject malicious code into the artifacts that you are resolving and infect build artifacts that are being produced. This can be used by attackers to perform a [supply chain attack](https://en.wikipedia.org/wiki/Supply_chain_attack) against your project's users.\n\n\n## Recommendation\nAlways use the canonical repository for resolving your dependencies.\n\n\n## Example\nThe following example shows locations in a Maven POM file where artifact repository upload/download is configured. The use of Bintray in any of these locations is not advised.\n\n\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n\n    <modelVersion>4.0.0</modelVersion>\n\n    <groupId>com.semmle</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n    <packaging>pom</packaging>\n\n    <name>Bintray Usage</name>\n    <description>An example of using bintray to download and upload dependencies</description>\n\n    <distributionManagement>\n        <repository>\n            <id>jcenter</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </repository>\n        <snapshotRepository>\n            <id>jcenter-snapshots</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </snapshotRepository>\n    </distributionManagement>\n    <repositories>\n        <repository>\n            <id>jcenter</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </repository>\n    </repositories>\n    <repositories>\n        <repository>\n            <id>jcenter</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use Bintray -->\n            <url>https://dl.bintray.com/groovy/maven</url>\n        </repository>\n    </repositories>\n    <pluginRepositories>\n        <pluginRepository>\n            <id>jcenter-plugins</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </pluginRepository>\n    </pluginRepositories>\n</project>\n\n```\n\n## References\n* JFrog blog: [ Into the Sunset on May 1st: Bintray, JCenter, GoCenter, and ChartCenter ](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)\n* Common Weakness Enumeration: [CWE-1104](https://cwe.mitre.org/data/definitions/1104.html).\n",
+                                    "markdown": "# Depending upon JCenter/Bintray as an artifact repository\n[Bintray and JCenter are shutting down on February 1st, 2022](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). Relying upon repositories that are deprecated or scheduled to be shutdown can have unintended consequences; for example, artifacts being resolved from a different artifact server or a total failure of the CI build.\n\nWhen artifact repositories are left unmaintained for a long period of time, vulnerabilities may emerge. Theoretically, this could allow attackers to inject malicious code into the artifacts that you are resolving and infect build artifacts that are being produced. This can be used by attackers to perform a [supply chain attack](https://en.wikipedia.org/wiki/Supply_chain_attack) against your project's users.\n\n\n## Recommendation\nAlways use the canonical repository for resolving your dependencies.\n\n\n## Example\nThe following example shows locations in a Maven POM file where artifact repository upload/download is configured. The use of Bintray in any of these locations is not advised.\n\n\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n\n    <modelVersion>4.0.0</modelVersion>\n\n    <groupId>com.semmle</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n    <packaging>pom</packaging>\n\n    <name>Bintray Usage</name>\n    <description>An example of using bintray to download and upload dependencies</description>\n\n    <distributionManagement>\n        <repository>\n            <id>jcenter</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </repository>\n        <snapshotRepository>\n            <id>jcenter-snapshots</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </snapshotRepository>\n    </distributionManagement>\n    <repositories>\n        <repository>\n            <id>jcenter</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </repository>\n    </repositories>\n    <repositories>\n        <repository>\n            <id>jcenter</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use Bintray -->\n            <url>https://dl.bintray.com/groovy/maven</url>\n        </repository>\n    </repositories>\n    <pluginRepositories>\n        <pluginRepository>\n            <id>jcenter-plugins</id>\n            <name>JCenter</name>\n            <!-- BAD! Don't use JCenter -->\n            <url>https://jcenter.bintray.com</url>\n        </pluginRepository>\n    </pluginRepositories>\n</project>\n\n```\n\n## References\n* JFrog blog: [ Into the Sunset on May 1st: Bintray, JCenter, GoCenter, and ChartCenter ](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)\n* Common Weakness Enumeration: [CWE-1104](https://cwe.mitre.org/data/definitions/1104.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-1104"
+                                    ],
+                                    "description": "Using a deprecated artifact repository may eventually give attackers access for a supply chain attack.",
+                                    "id": "java/maven/dependency-upon-bintray",
+                                    "kind": "problem",
+                                    "name": "Depending upon JCenter/Bintray as an artifact repository",
+                                    "precision": "very-high",
+                                    "problem.severity": "error",
+                                    "security-severity": "6.5"
+                                }
+                            },
+                            {
+                                "id": "java/netty-http-request-or-response-splitting",
+                                "name": "java/netty-http-request-or-response-splitting",
+                                "shortDescription": {
+                                    "text": "Disabled Netty HTTP header validation"
+                                },
+                                "fullDescription": {
+                                    "text": "Disabling HTTP header validation makes code vulnerable to attack by header splitting if user input is written directly to an HTTP header."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Disabled Netty HTTP header validation\nDirectly writing user input (for example, an HTTP request parameter) to an HTTP header can lead to an HTTP request-splitting or response-splitting vulnerability.\n\nHTTP response splitting can lead to vulnerabilities such as XSS and cache poisoning.\n\nHTTP request splitting can allow an attacker to inject an additional HTTP request into a client's outgoing socket connection. This can allow an attacker to perform an SSRF-like attack.\n\nIn the context of a servlet container, if the user input includes blank lines and the servlet container does not escape the blank lines, then a remote user can cause the response to turn into two separate responses. The remote user can then control one or more responses, which is also HTTP response splitting.\n\n\n## Recommendation\nGuard against HTTP header splitting in the same way as guarding against cross-site scripting. Before passing any data into HTTP headers, either check the data for special characters, or escape any special characters that are present.\n\nIf the code calls Netty API's directly, ensure that the `validateHeaders` parameter is set to `true`.\n\n\n## Example\nThe following example shows the 'name' parameter being written to a cookie in two different ways. The first way writes it directly to the cookie, and thus is vulnerable to response-splitting attacks. The second way first removes all special characters, thus avoiding the potential problem.\n\n\n```java\npublic class ResponseSplitting extends HttpServlet {\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: setting a cookie with an unvalidated parameter\n\t\tCookie cookie = new Cookie(\"name\", request.getParameter(\"name\"));\n\t\tresponse.addCookie(cookie);\n\n\t\t// GOOD: remove special characters before putting them in the header\n\t\tString name = removeSpecial(request.getParameter(\"name\"));\n\t\tCookie cookie2 = new Cookie(\"name\", name);\n\t\tresponse.addCookie(cookie2);\n\t}\n\n\tprivate static String removeSpecial(String str) {\n\t\treturn str.replaceAll(\"[^a-zA-Z ]\", \"\");\n\t}\n}\n\n```\n\n## Example\nThe following example shows the use of the library 'netty' with HTTP response-splitting verification configurations. The second way will verify the parameters before using them to build the HTTP response.\n\n\n```java\nimport io.netty.handler.codec.http.DefaultHttpHeaders;\n\npublic class ResponseSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpResponse badResponse = new DefaultHttpResponse(version, httpResponseStatus, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpResponse goodResponse = new DefaultHttpResponse(version, httpResponseStatus);\n}\n\n```\n\n## Example\nThe following example shows the use of the netty library with configurations for verification of HTTP request splitting. The second recommended approach in the example verifies the parameters before using them to build the HTTP request.\n\n\n```java\npublic class NettyRequestSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpRequest badRequest = new DefaultHttpRequest(httpVersion, method, uri, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpRequest goodResponse = new DefaultHttpRequest(httpVersion, method, uri);\n}\n\n```\n\n## References\n* SecLists.org: [HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187).\n* OWASP: [HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting).\n* Wikipedia: [HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting).\n* CAPEC: [CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)\n* Common Weakness Enumeration: [CWE-93](https://cwe.mitre.org/data/definitions/93.html).\n* Common Weakness Enumeration: [CWE-113](https://cwe.mitre.org/data/definitions/113.html).\n",
+                                    "markdown": "# Disabled Netty HTTP header validation\nDirectly writing user input (for example, an HTTP request parameter) to an HTTP header can lead to an HTTP request-splitting or response-splitting vulnerability.\n\nHTTP response splitting can lead to vulnerabilities such as XSS and cache poisoning.\n\nHTTP request splitting can allow an attacker to inject an additional HTTP request into a client's outgoing socket connection. This can allow an attacker to perform an SSRF-like attack.\n\nIn the context of a servlet container, if the user input includes blank lines and the servlet container does not escape the blank lines, then a remote user can cause the response to turn into two separate responses. The remote user can then control one or more responses, which is also HTTP response splitting.\n\n\n## Recommendation\nGuard against HTTP header splitting in the same way as guarding against cross-site scripting. Before passing any data into HTTP headers, either check the data for special characters, or escape any special characters that are present.\n\nIf the code calls Netty API's directly, ensure that the `validateHeaders` parameter is set to `true`.\n\n\n## Example\nThe following example shows the 'name' parameter being written to a cookie in two different ways. The first way writes it directly to the cookie, and thus is vulnerable to response-splitting attacks. The second way first removes all special characters, thus avoiding the potential problem.\n\n\n```java\npublic class ResponseSplitting extends HttpServlet {\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: setting a cookie with an unvalidated parameter\n\t\tCookie cookie = new Cookie(\"name\", request.getParameter(\"name\"));\n\t\tresponse.addCookie(cookie);\n\n\t\t// GOOD: remove special characters before putting them in the header\n\t\tString name = removeSpecial(request.getParameter(\"name\"));\n\t\tCookie cookie2 = new Cookie(\"name\", name);\n\t\tresponse.addCookie(cookie2);\n\t}\n\n\tprivate static String removeSpecial(String str) {\n\t\treturn str.replaceAll(\"[^a-zA-Z ]\", \"\");\n\t}\n}\n\n```\n\n## Example\nThe following example shows the use of the library 'netty' with HTTP response-splitting verification configurations. The second way will verify the parameters before using them to build the HTTP response.\n\n\n```java\nimport io.netty.handler.codec.http.DefaultHttpHeaders;\n\npublic class ResponseSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpResponse badResponse = new DefaultHttpResponse(version, httpResponseStatus, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpResponse goodResponse = new DefaultHttpResponse(version, httpResponseStatus);\n}\n\n```\n\n## Example\nThe following example shows the use of the netty library with configurations for verification of HTTP request splitting. The second recommended approach in the example verifies the parameters before using them to build the HTTP request.\n\n\n```java\npublic class NettyRequestSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpRequest badRequest = new DefaultHttpRequest(httpVersion, method, uri, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpRequest goodResponse = new DefaultHttpRequest(httpVersion, method, uri);\n}\n\n```\n\n## References\n* SecLists.org: [HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187).\n* OWASP: [HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting).\n* Wikipedia: [HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting).\n* CAPEC: [CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)\n* Common Weakness Enumeration: [CWE-93](https://cwe.mitre.org/data/definitions/93.html).\n* Common Weakness Enumeration: [CWE-113](https://cwe.mitre.org/data/definitions/113.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-93",
+                                        "external/cwe/cwe-113"
+                                    ],
+                                    "description": "Disabling HTTP header validation makes code vulnerable to\n              attack by header splitting if user input is written directly to\n              an HTTP header.",
+                                    "id": "java/netty-http-request-or-response-splitting",
+                                    "kind": "problem",
+                                    "name": "Disabled Netty HTTP header validation",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "6.1"
+                                }
+                            },
+                            {
+                                "id": "java/http-response-splitting",
+                                "name": "java/http-response-splitting",
+                                "shortDescription": {
+                                    "text": "HTTP response splitting"
+                                },
+                                "fullDescription": {
+                                    "text": "Writing user input directly to an HTTP header makes code vulnerable to attack by header splitting."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# HTTP response splitting\nDirectly writing user input (for example, an HTTP request parameter) to an HTTP header can lead to an HTTP request-splitting or response-splitting vulnerability.\n\nHTTP response splitting can lead to vulnerabilities such as XSS and cache poisoning.\n\nHTTP request splitting can allow an attacker to inject an additional HTTP request into a client's outgoing socket connection. This can allow an attacker to perform an SSRF-like attack.\n\nIn the context of a servlet container, if the user input includes blank lines and the servlet container does not escape the blank lines, then a remote user can cause the response to turn into two separate responses. The remote user can then control one or more responses, which is also HTTP response splitting.\n\n\n## Recommendation\nGuard against HTTP header splitting in the same way as guarding against cross-site scripting. Before passing any data into HTTP headers, either check the data for special characters, or escape any special characters that are present.\n\nIf the code calls Netty API's directly, ensure that the `validateHeaders` parameter is set to `true`.\n\n\n## Example\nThe following example shows the 'name' parameter being written to a cookie in two different ways. The first way writes it directly to the cookie, and thus is vulnerable to response-splitting attacks. The second way first removes all special characters, thus avoiding the potential problem.\n\n\n```java\npublic class ResponseSplitting extends HttpServlet {\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: setting a cookie with an unvalidated parameter\n\t\tCookie cookie = new Cookie(\"name\", request.getParameter(\"name\"));\n\t\tresponse.addCookie(cookie);\n\n\t\t// GOOD: remove special characters before putting them in the header\n\t\tString name = removeSpecial(request.getParameter(\"name\"));\n\t\tCookie cookie2 = new Cookie(\"name\", name);\n\t\tresponse.addCookie(cookie2);\n\t}\n\n\tprivate static String removeSpecial(String str) {\n\t\treturn str.replaceAll(\"[^a-zA-Z ]\", \"\");\n\t}\n}\n\n```\n\n## Example\nThe following example shows the use of the library 'netty' with HTTP response-splitting verification configurations. The second way will verify the parameters before using them to build the HTTP response.\n\n\n```java\nimport io.netty.handler.codec.http.DefaultHttpHeaders;\n\npublic class ResponseSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpResponse badResponse = new DefaultHttpResponse(version, httpResponseStatus, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpResponse goodResponse = new DefaultHttpResponse(version, httpResponseStatus);\n}\n\n```\n\n## Example\nThe following example shows the use of the netty library with configurations for verification of HTTP request splitting. The second recommended approach in the example verifies the parameters before using them to build the HTTP request.\n\n\n```java\npublic class NettyRequestSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpRequest badRequest = new DefaultHttpRequest(httpVersion, method, uri, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpRequest goodResponse = new DefaultHttpRequest(httpVersion, method, uri);\n}\n\n```\n\n## References\n* SecLists.org: [HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187).\n* OWASP: [HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting).\n* Wikipedia: [HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting).\n* CAPEC: [CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)\n* Common Weakness Enumeration: [CWE-113](https://cwe.mitre.org/data/definitions/113.html).\n",
+                                    "markdown": "# HTTP response splitting\nDirectly writing user input (for example, an HTTP request parameter) to an HTTP header can lead to an HTTP request-splitting or response-splitting vulnerability.\n\nHTTP response splitting can lead to vulnerabilities such as XSS and cache poisoning.\n\nHTTP request splitting can allow an attacker to inject an additional HTTP request into a client's outgoing socket connection. This can allow an attacker to perform an SSRF-like attack.\n\nIn the context of a servlet container, if the user input includes blank lines and the servlet container does not escape the blank lines, then a remote user can cause the response to turn into two separate responses. The remote user can then control one or more responses, which is also HTTP response splitting.\n\n\n## Recommendation\nGuard against HTTP header splitting in the same way as guarding against cross-site scripting. Before passing any data into HTTP headers, either check the data for special characters, or escape any special characters that are present.\n\nIf the code calls Netty API's directly, ensure that the `validateHeaders` parameter is set to `true`.\n\n\n## Example\nThe following example shows the 'name' parameter being written to a cookie in two different ways. The first way writes it directly to the cookie, and thus is vulnerable to response-splitting attacks. The second way first removes all special characters, thus avoiding the potential problem.\n\n\n```java\npublic class ResponseSplitting extends HttpServlet {\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: setting a cookie with an unvalidated parameter\n\t\tCookie cookie = new Cookie(\"name\", request.getParameter(\"name\"));\n\t\tresponse.addCookie(cookie);\n\n\t\t// GOOD: remove special characters before putting them in the header\n\t\tString name = removeSpecial(request.getParameter(\"name\"));\n\t\tCookie cookie2 = new Cookie(\"name\", name);\n\t\tresponse.addCookie(cookie2);\n\t}\n\n\tprivate static String removeSpecial(String str) {\n\t\treturn str.replaceAll(\"[^a-zA-Z ]\", \"\");\n\t}\n}\n\n```\n\n## Example\nThe following example shows the use of the library 'netty' with HTTP response-splitting verification configurations. The second way will verify the parameters before using them to build the HTTP response.\n\n\n```java\nimport io.netty.handler.codec.http.DefaultHttpHeaders;\n\npublic class ResponseSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpResponse badResponse = new DefaultHttpResponse(version, httpResponseStatus, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpResponse goodResponse = new DefaultHttpResponse(version, httpResponseStatus);\n}\n\n```\n\n## Example\nThe following example shows the use of the netty library with configurations for verification of HTTP request splitting. The second recommended approach in the example verifies the parameters before using them to build the HTTP request.\n\n\n```java\npublic class NettyRequestSplitting {\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();\n\n    // BAD: Disables the internal response splitting verification\n    private final DefaultHttpRequest badRequest = new DefaultHttpRequest(httpVersion, method, uri, false);\n\n    // GOOD: Verifies headers passed don't contain CRLF characters\n    private final DefaultHttpRequest goodResponse = new DefaultHttpRequest(httpVersion, method, uri);\n}\n\n```\n\n## References\n* SecLists.org: [HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187).\n* OWASP: [HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting).\n* Wikipedia: [HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting).\n* CAPEC: [CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)\n* Common Weakness Enumeration: [CWE-113](https://cwe.mitre.org/data/definitions/113.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-113"
+                                    ],
+                                    "description": "Writing user input directly to an HTTP header\n              makes code vulnerable to attack by header splitting.",
+                                    "id": "java/http-response-splitting",
+                                    "kind": "path-problem",
+                                    "name": "HTTP response splitting",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "6.1"
+                                }
+                            },
+                            {
+                                "id": "java/world-writable-file-read",
+                                "name": "java/world-writable-file-read",
+                                "shortDescription": {
+                                    "text": "Reading from a world writable file"
+                                },
+                                "fullDescription": {
+                                    "text": "Reading from a file which is set as world writable is dangerous because the file may be modified or removed by external actors."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Reading from a world writable file\nReading from a world-writable file is dangerous on a multi-user system because other users may be able to affect program execution by modifying or deleting the file.\n\n\n## Recommendation\nDo not make files explicitly world writable unless the file is intended to be written by multiple users on a multi-user system. In many cases, the file may only need to be writable for the current user.\n\nFor some file systems, there may be alternatives to setting the file to be world writable. For example, POSIX file systems support \"groups\" which may be used to ensure that only subset of all the users can write to the file. Access Control Lists (ACLs) are available for many operating system and file system combinations, and can provide fine-grained read and write support without resorting to world writable permissions.\n\n\n## Example\nIn the following example, we are loading some configuration parameters from a file:\n\n```java\n\nprivate void readConfig(File configFile) {\n  if (!configFile.exists()) {\n    // Create an empty config file\n    configFile.createNewFile();\n    // Make the file writable for all\n    configFile.setWritable(true, false);\n  }\n  // Now read the config\n  loadConfig(configFile);\n}\n\n```\nIf the configuration file does not yet exist, an empty file is created. Creating an empty file can simplify the later code and is a convenience for the user. However, by setting the file to be world writable, we allow any user on the system to modify the configuration, not just the current user. If there may be untrusted users on the system, this is potentially dangerous.\n\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [FIO01-J. Create files with appropriate access permissions](https://wiki.sei.cmu.edu/confluence/display/java/FIO01-J.+Create+files+with+appropriate+access+permissions).\n* Common Weakness Enumeration: [CWE-732](https://cwe.mitre.org/data/definitions/732.html).\n",
+                                    "markdown": "# Reading from a world writable file\nReading from a world-writable file is dangerous on a multi-user system because other users may be able to affect program execution by modifying or deleting the file.\n\n\n## Recommendation\nDo not make files explicitly world writable unless the file is intended to be written by multiple users on a multi-user system. In many cases, the file may only need to be writable for the current user.\n\nFor some file systems, there may be alternatives to setting the file to be world writable. For example, POSIX file systems support \"groups\" which may be used to ensure that only subset of all the users can write to the file. Access Control Lists (ACLs) are available for many operating system and file system combinations, and can provide fine-grained read and write support without resorting to world writable permissions.\n\n\n## Example\nIn the following example, we are loading some configuration parameters from a file:\n\n```java\n\nprivate void readConfig(File configFile) {\n  if (!configFile.exists()) {\n    // Create an empty config file\n    configFile.createNewFile();\n    // Make the file writable for all\n    configFile.setWritable(true, false);\n  }\n  // Now read the config\n  loadConfig(configFile);\n}\n\n```\nIf the configuration file does not yet exist, an empty file is created. Creating an empty file can simplify the later code and is a convenience for the user. However, by setting the file to be world writable, we allow any user on the system to modify the configuration, not just the current user. If there may be untrusted users on the system, this is potentially dangerous.\n\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [FIO01-J. Create files with appropriate access permissions](https://wiki.sei.cmu.edu/confluence/display/java/FIO01-J.+Create+files+with+appropriate+access+permissions).\n* Common Weakness Enumeration: [CWE-732](https://cwe.mitre.org/data/definitions/732.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-732"
+                                    ],
+                                    "description": "Reading from a file which is set as world writable is dangerous because\n              the file may be modified or removed by external actors.",
+                                    "id": "java/world-writable-file-read",
+                                    "kind": "problem",
+                                    "name": "Reading from a world writable file",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.8"
+                                }
+                            },
+                            {
+                                "id": "java/zipslip",
+                                "name": "java/zipslip",
+                                "shortDescription": {
+                                    "text": "Arbitrary file write during archive extraction (\"Zip Slip\")"
+                                },
+                                "fullDescription": {
+                                    "text": "Extracting files from a malicious archive without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Arbitrary file write during archive extraction (\"Zip Slip\")\nExtracting files from a malicious zip archive (or another archive format) without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten, due to the possible presence of directory traversal elements (`..`) in archive paths.\n\nZip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to determine an output file to write the contents of the archive item to, then the file may be written to an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.\n\nFor example, if a zip file contains a file entry `..\\sneaky-file`, and the zip file is extracted to the directory `c:\\output`, then naively combining the paths would result in an output file path of `c:\\output\\..\\sneaky-file`, which would cause the file to be written to `c:\\sneaky-file`.\n\n\n## Recommendation\nEnsure that output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations.\n\nThe recommended way of writing an output file from a zip archive entry is to verify that the normalized full path of the output file starts with a prefix that matches the destination directory. Path normalization can be done with either `java.io.File.getCanonicalFile()` or `java.nio.file.Path.normalize()`. Prefix checking can be done with `String.startsWith(..)`, but it is better to use `java.nio.file.Path.startsWith(..)`, as the latter works on complete path segments.\n\nAnother alternative is to validate archive entries against a whitelist of expected files.\n\n\n## Example\nIn this example, a file path taken from a zip archive item entry is combined with a destination directory. The result is used as the destination file path without verifying that the result is within the destination directory. If provided with a zip file containing an archive path like `..\\sneaky-file`, then this file would be written outside the destination directory.\n\n\n```java\nvoid writeZipEntry(ZipEntry entry, File destinationDir) {\n    File file = new File(destinationDir, entry.getName());\n    FileOutputStream fos = new FileOutputStream(file); // BAD\n    // ... write entry to fos ...\n}\n\n```\nTo fix this vulnerability, we need to verify that the normalized `file` still has `destinationDir` as its prefix, and throw an exception if this is not the case.\n\n\n```java\nvoid writeZipEntry(ZipEntry entry, File destinationDir) {\n    File file = new File(destinationDir, entry.getName());\n    if (!file.toPath().normalize().startsWith(destinationDir.toPath()))\n        throw new Exception(\"Bad zip entry\");\n    FileOutputStream fos = new FileOutputStream(file); // OK\n    // ... write entry to fos ...\n}\n\n```\n\n## References\n* Snyk: [Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability).\n* OWASP: [Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).\n* Common Weakness Enumeration: [CWE-22](https://cwe.mitre.org/data/definitions/22.html).\n",
+                                    "markdown": "# Arbitrary file write during archive extraction (\"Zip Slip\")\nExtracting files from a malicious zip archive (or another archive format) without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten, due to the possible presence of directory traversal elements (`..`) in archive paths.\n\nZip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to determine an output file to write the contents of the archive item to, then the file may be written to an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.\n\nFor example, if a zip file contains a file entry `..\\sneaky-file`, and the zip file is extracted to the directory `c:\\output`, then naively combining the paths would result in an output file path of `c:\\output\\..\\sneaky-file`, which would cause the file to be written to `c:\\sneaky-file`.\n\n\n## Recommendation\nEnsure that output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations.\n\nThe recommended way of writing an output file from a zip archive entry is to verify that the normalized full path of the output file starts with a prefix that matches the destination directory. Path normalization can be done with either `java.io.File.getCanonicalFile()` or `java.nio.file.Path.normalize()`. Prefix checking can be done with `String.startsWith(..)`, but it is better to use `java.nio.file.Path.startsWith(..)`, as the latter works on complete path segments.\n\nAnother alternative is to validate archive entries against a whitelist of expected files.\n\n\n## Example\nIn this example, a file path taken from a zip archive item entry is combined with a destination directory. The result is used as the destination file path without verifying that the result is within the destination directory. If provided with a zip file containing an archive path like `..\\sneaky-file`, then this file would be written outside the destination directory.\n\n\n```java\nvoid writeZipEntry(ZipEntry entry, File destinationDir) {\n    File file = new File(destinationDir, entry.getName());\n    FileOutputStream fos = new FileOutputStream(file); // BAD\n    // ... write entry to fos ...\n}\n\n```\nTo fix this vulnerability, we need to verify that the normalized `file` still has `destinationDir` as its prefix, and throw an exception if this is not the case.\n\n\n```java\nvoid writeZipEntry(ZipEntry entry, File destinationDir) {\n    File file = new File(destinationDir, entry.getName());\n    if (!file.toPath().normalize().startsWith(destinationDir.toPath()))\n        throw new Exception(\"Bad zip entry\");\n    FileOutputStream fos = new FileOutputStream(file); // OK\n    // ... write entry to fos ...\n}\n\n```\n\n## References\n* Snyk: [Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability).\n* OWASP: [Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).\n* Common Weakness Enumeration: [CWE-22](https://cwe.mitre.org/data/definitions/22.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-022"
+                                    ],
+                                    "description": "Extracting files from a malicious archive without validating that the\n              destination file path is within the destination directory can cause files outside\n              the destination directory to be overwritten.",
+                                    "id": "java/zipslip",
+                                    "kind": "path-problem",
+                                    "name": "Arbitrary file write during archive extraction (\"Zip Slip\")",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/path-injection",
+                                "name": "java/path-injection",
+                                "shortDescription": {
+                                    "text": "Uncontrolled data used in path expression"
+                                },
+                                "fullDescription": {
+                                    "text": "Accessing paths influenced by users can allow an attacker to access unexpected resources."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Uncontrolled data used in path expression\nAccessing paths controlled by users can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.\n\nPaths that are naively constructed from data controlled by a user may contain unexpected special characters, such as \"..\". Such a path may potentially point to any directory on the file system.\n\n\n## Recommendation\nValidate user input before using it to construct a file path. Ideally, follow these rules:\n\n* Do not allow more than a single \".\" character.\n* Do not allow directory separators such as \"/\" or \"\\\\\" (depending on the file system).\n* Do not rely on simply replacing problematic sequences such as \"../\". For example, after applying this filter to \".../...//\" the resulting string would still be \"../\".\n* Ideally use a whitelist of known good patterns.\n\n## Example\nIn this example, a file name is read from a `java.net.Socket` and then used to access a file in the user's home directory and send it back over the socket. However, a malicious user could enter a file name which contains special characters. For example, the string \"../../etc/passwd\" will result in the code reading the file located at \"/home/\\[user\\]/../../etc/passwd\", which is the system's password file. This file would then be sent back to the user, giving them access to all the system's passwords.\n\n\n```java\npublic void sendUserFile(Socket sock, String user) {\n\tBufferedReader filenameReader = new BufferedReader(\n\t\t\tnew InputStreamReader(sock.getInputStream(), \"UTF-8\"));\n\tString filename = filenameReader.readLine();\n\t// BAD: read from a file using a path controlled by the user\n\tBufferedReader fileReader = new BufferedReader(\n\t\t\tnew FileReader(\"/home/\" + user + \"/\" + filename));\n\tString fileLine = fileReader.readLine();\n\twhile(fileLine != null) {\n\t\tsock.getOutputStream().write(fileLine.getBytes());\n\t\tfileLine = fileReader.readLine();\n\t}\n}\n\npublic void sendUserFileFixed(Socket sock, String user) {\n\t// ...\n\t\n\t// GOOD: remove all dots and directory delimiters from the filename before using\n\tString filename = filenameReader.readLine().replaceAll(\"\\\\.\", \"\").replaceAll(\"/\", \"\");\n\tBufferedReader fileReader = new BufferedReader(\n\t\t\tnew FileReader(\"/home/\" + user + \"/\" + filename));\n\n\t// ...\n}\n\n```\n\n## References\n* OWASP: [Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).\n* Common Weakness Enumeration: [CWE-22](https://cwe.mitre.org/data/definitions/22.html).\n* Common Weakness Enumeration: [CWE-23](https://cwe.mitre.org/data/definitions/23.html).\n* Common Weakness Enumeration: [CWE-36](https://cwe.mitre.org/data/definitions/36.html).\n* Common Weakness Enumeration: [CWE-73](https://cwe.mitre.org/data/definitions/73.html).\n",
+                                    "markdown": "# Uncontrolled data used in path expression\nAccessing paths controlled by users can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.\n\nPaths that are naively constructed from data controlled by a user may contain unexpected special characters, such as \"..\". Such a path may potentially point to any directory on the file system.\n\n\n## Recommendation\nValidate user input before using it to construct a file path. Ideally, follow these rules:\n\n* Do not allow more than a single \".\" character.\n* Do not allow directory separators such as \"/\" or \"\\\\\" (depending on the file system).\n* Do not rely on simply replacing problematic sequences such as \"../\". For example, after applying this filter to \".../...//\" the resulting string would still be \"../\".\n* Ideally use a whitelist of known good patterns.\n\n## Example\nIn this example, a file name is read from a `java.net.Socket` and then used to access a file in the user's home directory and send it back over the socket. However, a malicious user could enter a file name which contains special characters. For example, the string \"../../etc/passwd\" will result in the code reading the file located at \"/home/\\[user\\]/../../etc/passwd\", which is the system's password file. This file would then be sent back to the user, giving them access to all the system's passwords.\n\n\n```java\npublic void sendUserFile(Socket sock, String user) {\n\tBufferedReader filenameReader = new BufferedReader(\n\t\t\tnew InputStreamReader(sock.getInputStream(), \"UTF-8\"));\n\tString filename = filenameReader.readLine();\n\t// BAD: read from a file using a path controlled by the user\n\tBufferedReader fileReader = new BufferedReader(\n\t\t\tnew FileReader(\"/home/\" + user + \"/\" + filename));\n\tString fileLine = fileReader.readLine();\n\twhile(fileLine != null) {\n\t\tsock.getOutputStream().write(fileLine.getBytes());\n\t\tfileLine = fileReader.readLine();\n\t}\n}\n\npublic void sendUserFileFixed(Socket sock, String user) {\n\t// ...\n\t\n\t// GOOD: remove all dots and directory delimiters from the filename before using\n\tString filename = filenameReader.readLine().replaceAll(\"\\\\.\", \"\").replaceAll(\"/\", \"\");\n\tBufferedReader fileReader = new BufferedReader(\n\t\t\tnew FileReader(\"/home/\" + user + \"/\" + filename));\n\n\t// ...\n}\n\n```\n\n## References\n* OWASP: [Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).\n* Common Weakness Enumeration: [CWE-22](https://cwe.mitre.org/data/definitions/22.html).\n* Common Weakness Enumeration: [CWE-23](https://cwe.mitre.org/data/definitions/23.html).\n* Common Weakness Enumeration: [CWE-36](https://cwe.mitre.org/data/definitions/36.html).\n* Common Weakness Enumeration: [CWE-73](https://cwe.mitre.org/data/definitions/73.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-022",
+                                        "external/cwe/cwe-023",
+                                        "external/cwe/cwe-036",
+                                        "external/cwe/cwe-073"
+                                    ],
+                                    "description": "Accessing paths influenced by users can allow an attacker to access unexpected resources.",
+                                    "id": "java/path-injection",
+                                    "kind": "path-problem",
+                                    "name": "Uncontrolled data used in path expression",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/android/intent-redirection",
+                                "name": "java/android/intent-redirection",
+                                "shortDescription": {
+                                    "text": "Android Intent redirection"
+                                },
+                                "fullDescription": {
+                                    "text": "Starting Android components with user-provided Intents can provide access to internal components of the application, increasing the attack surface and potentially causing unintended effects."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Android Intent redirection\nAn exported Android component that obtains a user-provided Intent and uses it to launch another component can be exploited to obtain access to private, unexported components of the same app or to launch other apps' components on behalf of the victim app.\n\n\n## Recommendation\nDo not export components that start other components from a user-provided Intent. They can be made private by setting the `android:exported` property to `false` in the app's Android Manifest.\n\nIf this is not possible, restrict either which apps can send Intents to the affected component, or which components can be started from it.\n\n\n## Example\nThe following snippet contains three examples. In the first example, an arbitrary component can be started from the externally provided `forward_intent` Intent. In the second example, the destination component of the Intent is first checked to make sure it is safe. In the third example, the component that created the Intent is first checked to make sure it comes from a trusted origin.\n\n\n```java\n// BAD: A user-provided Intent is used to launch an arbitrary component\nIntent forwardIntent = (Intent) getIntent().getParcelableExtra(\"forward_intent\");\nstartActivity(forwardIntent);\n\n// GOOD: The destination component is checked before launching it\nIntent forwardIntent = (Intent) getIntent().getParcelableExtra(\"forward_intent\");\nComponentName destinationComponent = forwardIntent.resolveActivity(getPackageManager());\nif (destinationComponent.getPackageName().equals(\"safe.package\") && \n    destinationComponent.getClassName().equals(\"SafeClass\")) {\n    startActivity(forwardIntent);\n}\n\n// GOOD: The component that sent the Intent is checked before launching the destination component\nIntent forwardIntent = (Intent) getIntent().getParcelableExtra(\"forward_intent\");\nComponentName originComponent = getCallingActivity();\nif (originComponent.getPackageName().equals(\"trusted.package\") && originComponent.getClassName().equals(\"TrustedClass\")) {\n    startActivity(forwardIntent);\n}\n\n```\n\n## References\n* Google: [Remediation for Intent Redirection Vulnerability](https://support.google.com/faqs/answer/9267555?hl=en).\n* OWASP Mobile Security Testing Guide: [Intents](https://mobile-security.gitbook.io/mobile-security-testing-guide/android-testing-guide/0x05a-platform-overview#intents).\n* Android Developers: [The android:exported attribute](https://developer.android.com/guide/topics/manifest/activity-element#exported).\n* Common Weakness Enumeration: [CWE-926](https://cwe.mitre.org/data/definitions/926.html).\n* Common Weakness Enumeration: [CWE-940](https://cwe.mitre.org/data/definitions/940.html).\n",
+                                    "markdown": "# Android Intent redirection\nAn exported Android component that obtains a user-provided Intent and uses it to launch another component can be exploited to obtain access to private, unexported components of the same app or to launch other apps' components on behalf of the victim app.\n\n\n## Recommendation\nDo not export components that start other components from a user-provided Intent. They can be made private by setting the `android:exported` property to `false` in the app's Android Manifest.\n\nIf this is not possible, restrict either which apps can send Intents to the affected component, or which components can be started from it.\n\n\n## Example\nThe following snippet contains three examples. In the first example, an arbitrary component can be started from the externally provided `forward_intent` Intent. In the second example, the destination component of the Intent is first checked to make sure it is safe. In the third example, the component that created the Intent is first checked to make sure it comes from a trusted origin.\n\n\n```java\n// BAD: A user-provided Intent is used to launch an arbitrary component\nIntent forwardIntent = (Intent) getIntent().getParcelableExtra(\"forward_intent\");\nstartActivity(forwardIntent);\n\n// GOOD: The destination component is checked before launching it\nIntent forwardIntent = (Intent) getIntent().getParcelableExtra(\"forward_intent\");\nComponentName destinationComponent = forwardIntent.resolveActivity(getPackageManager());\nif (destinationComponent.getPackageName().equals(\"safe.package\") && \n    destinationComponent.getClassName().equals(\"SafeClass\")) {\n    startActivity(forwardIntent);\n}\n\n// GOOD: The component that sent the Intent is checked before launching the destination component\nIntent forwardIntent = (Intent) getIntent().getParcelableExtra(\"forward_intent\");\nComponentName originComponent = getCallingActivity();\nif (originComponent.getPackageName().equals(\"trusted.package\") && originComponent.getClassName().equals(\"TrustedClass\")) {\n    startActivity(forwardIntent);\n}\n\n```\n\n## References\n* Google: [Remediation for Intent Redirection Vulnerability](https://support.google.com/faqs/answer/9267555?hl=en).\n* OWASP Mobile Security Testing Guide: [Intents](https://mobile-security.gitbook.io/mobile-security-testing-guide/android-testing-guide/0x05a-platform-overview#intents).\n* Android Developers: [The android:exported attribute](https://developer.android.com/guide/topics/manifest/activity-element#exported).\n* Common Weakness Enumeration: [CWE-926](https://cwe.mitre.org/data/definitions/926.html).\n* Common Weakness Enumeration: [CWE-940](https://cwe.mitre.org/data/definitions/940.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-926",
+                                        "external/cwe/cwe-940"
+                                    ],
+                                    "description": "Starting Android components with user-provided Intents\n              can provide access to internal components of the application,\n              increasing the attack surface and potentially causing unintended effects.",
+                                    "id": "java/android/intent-redirection",
+                                    "kind": "path-problem",
+                                    "name": "Android Intent redirection",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/android/implicitly-exported-component",
+                                "name": "java/android/implicitly-exported-component",
+                                "shortDescription": {
+                                    "text": "Implicitly exported Android component"
+                                },
+                                "fullDescription": {
+                                    "text": "Android components with an '<intent-filter>' and no 'android:exported' attribute are implicitly exported, which can allow for improper access to the components themselves and to their data."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Implicitly exported Android component\nThe Android manifest file defines configuration settings for Android applications. In this file, components can be declared with intent filters which specify what the components can do and what types of intents the components can respond to. If the `android:exported` attribute is omitted from the component when an intent filter is included, then the component will be implicitly exported.\n\nAn implicitly exported component could allow for improper access to the component and its data.\n\n\n## Recommendation\nExplicitly set the `android:exported` attribute for every component or use permissions to limit access to the component.\n\n\n## Example\nIn the example below, the `android:exported` attribute is omitted when an intent filter is used.\n\n\n```xml\n<manifest ... >\n    <application ...\n        <!-- BAD: this component is implicitly exported -->\n        <activity>\n            android:name=\".Activity\">\n            <intent-filter>\n                <action android:name=\"android.intent.action.VIEW\" />\n            </intent-filter>\n        </activity>\n    </application>\n</manifest>\n\n```\nA corrected version sets the `android:exported` attribute to `false`.\n\n\n```xml\n<manifest ... >\n    <application ...\n        <!-- GOOD: this component is not exported due to 'android:exported' explicitly set to 'false'-->\n        <activity>\n            android:name=\".Activity\">\n            android:exported=\"false\"\n            <intent-filter>\n                <action android:name=\"android.intent.action.VIEW\" />\n            </intent-filter>\n        </activity>\n    </application>\n</manifest>\n\n```\n\n## References\n* Android Developers: [App Manifest Overview](https://developer.android.com/guide/topics/manifest/manifest-intro).\n* Android Developers: [The &lt;intent-filter&gt; element](https://developer.android.com/guide/topics/manifest/intent-filter-element).\n* Android Developers: [The android:exported attribute](https://developer.android.com/guide/topics/manifest/activity-element#exported).\n* Android Developers: [The android:permission attribute](https://developer.android.com/guide/topics/manifest/activity-element#prmsn).\n* Android Developers: [Safer component exporting](https://developer.android.com/about/versions/12/behavior-changes-12#exported).\n* Common Weakness Enumeration: [CWE-926](https://cwe.mitre.org/data/definitions/926.html).\n",
+                                    "markdown": "# Implicitly exported Android component\nThe Android manifest file defines configuration settings for Android applications. In this file, components can be declared with intent filters which specify what the components can do and what types of intents the components can respond to. If the `android:exported` attribute is omitted from the component when an intent filter is included, then the component will be implicitly exported.\n\nAn implicitly exported component could allow for improper access to the component and its data.\n\n\n## Recommendation\nExplicitly set the `android:exported` attribute for every component or use permissions to limit access to the component.\n\n\n## Example\nIn the example below, the `android:exported` attribute is omitted when an intent filter is used.\n\n\n```xml\n<manifest ... >\n    <application ...\n        <!-- BAD: this component is implicitly exported -->\n        <activity>\n            android:name=\".Activity\">\n            <intent-filter>\n                <action android:name=\"android.intent.action.VIEW\" />\n            </intent-filter>\n        </activity>\n    </application>\n</manifest>\n\n```\nA corrected version sets the `android:exported` attribute to `false`.\n\n\n```xml\n<manifest ... >\n    <application ...\n        <!-- GOOD: this component is not exported due to 'android:exported' explicitly set to 'false'-->\n        <activity>\n            android:name=\".Activity\">\n            android:exported=\"false\"\n            <intent-filter>\n                <action android:name=\"android.intent.action.VIEW\" />\n            </intent-filter>\n        </activity>\n    </application>\n</manifest>\n\n```\n\n## References\n* Android Developers: [App Manifest Overview](https://developer.android.com/guide/topics/manifest/manifest-intro).\n* Android Developers: [The &lt;intent-filter&gt; element](https://developer.android.com/guide/topics/manifest/intent-filter-element).\n* Android Developers: [The android:exported attribute](https://developer.android.com/guide/topics/manifest/activity-element#exported).\n* Android Developers: [The android:permission attribute](https://developer.android.com/guide/topics/manifest/activity-element#prmsn).\n* Android Developers: [Safer component exporting](https://developer.android.com/about/versions/12/behavior-changes-12#exported).\n* Common Weakness Enumeration: [CWE-926](https://cwe.mitre.org/data/definitions/926.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-926"
+                                    ],
+                                    "description": "Android components with an '<intent-filter>' and no 'android:exported' attribute are implicitly exported, which can allow for improper access to the components themselves and to their data.",
+                                    "id": "java/android/implicitly-exported-component",
+                                    "kind": "problem",
+                                    "name": "Implicitly exported Android component",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "8.2"
+                                }
+                            },
+                            {
+                                "id": "java/overly-large-range",
+                                "name": "java/overly-large-range",
+                                "shortDescription": {
+                                    "text": "Overly permissive regular expression range"
+                                },
+                                "fullDescription": {
+                                    "text": "Overly permissive regular expression ranges match a wider range of characters than intended. This may allow an attacker to bypass a filter or sanitizer."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Overly permissive regular expression range\nIt's easy to write a regular expression range that matches a wider range of characters than you intended. For example, `/[a-zA-z]/` matches all lowercase and all uppercase letters, as you would expect, but it also matches the characters: `` [ \\ ] ^ _ ` ``.\n\nAnother common problem is failing to escape the dash character in a regular expression. An unescaped dash is interpreted as part of a range. For example, in the character class `[a-zA-Z0-9%=.,-_]` the last character range matches the 55 characters between `,` and `_` (both included), which overlaps with the range `[0-9]` and is clearly not intended by the writer.\n\n\n## Recommendation\nAvoid any confusion about which characters are included in the range by writing unambiguous regular expressions. Always check that character ranges match only the expected characters.\n\n\n## Example\nThe following example code is intended to check whether a string is a valid 6 digit hex color.\n\n```java\n\nimport java.util.regex.Pattern\npublic class Tester {\n    public static boolean is_valid_hex_color(String color) {\n        return Pattern.matches(\"#[0-9a-fA-f]{6}\", color);\n    }\n}\n\n```\nHowever, the `A-f` range is overly large and matches every uppercase character. It would parse a \"color\" like `#XXYYZZ` as valid.\n\nThe fix is to use an uppercase `A-F` range instead.\n\n```javascript\n\nimport java.util.regex.Pattern\npublic class Tester {\n    public static boolean is_valid_hex_color(String color) {\n        return Pattern.matches(\"#[0-9a-fA-F]{6}\", color);\n    }\n}\n\n```\n\n## References\n* GitHub Advisory Database: [CVE-2021-42740: Improper Neutralization of Special Elements used in a Command in Shell-quote](https://github.com/advisories/GHSA-g4rg-993r-mgx7)\n* wh0.github.io: [Exploiting CVE-2021-42740](https://wh0.github.io/2021/10/28/shell-quote-rce-exploiting.html)\n* Yosuke Ota: [no-obscure-range](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html)\n* Paul Boyd: [The regex \\[,-.\\]](https://pboyd.io/posts/comma-dash-dot/)\n* Common Weakness Enumeration: [CWE-20](https://cwe.mitre.org/data/definitions/20.html).\n",
+                                    "markdown": "# Overly permissive regular expression range\nIt's easy to write a regular expression range that matches a wider range of characters than you intended. For example, `/[a-zA-z]/` matches all lowercase and all uppercase letters, as you would expect, but it also matches the characters: `` [ \\ ] ^ _ ` ``.\n\nAnother common problem is failing to escape the dash character in a regular expression. An unescaped dash is interpreted as part of a range. For example, in the character class `[a-zA-Z0-9%=.,-_]` the last character range matches the 55 characters between `,` and `_` (both included), which overlaps with the range `[0-9]` and is clearly not intended by the writer.\n\n\n## Recommendation\nAvoid any confusion about which characters are included in the range by writing unambiguous regular expressions. Always check that character ranges match only the expected characters.\n\n\n## Example\nThe following example code is intended to check whether a string is a valid 6 digit hex color.\n\n```java\n\nimport java.util.regex.Pattern\npublic class Tester {\n    public static boolean is_valid_hex_color(String color) {\n        return Pattern.matches(\"#[0-9a-fA-f]{6}\", color);\n    }\n}\n\n```\nHowever, the `A-f` range is overly large and matches every uppercase character. It would parse a \"color\" like `#XXYYZZ` as valid.\n\nThe fix is to use an uppercase `A-F` range instead.\n\n```javascript\n\nimport java.util.regex.Pattern\npublic class Tester {\n    public static boolean is_valid_hex_color(String color) {\n        return Pattern.matches(\"#[0-9a-fA-F]{6}\", color);\n    }\n}\n\n```\n\n## References\n* GitHub Advisory Database: [CVE-2021-42740: Improper Neutralization of Special Elements used in a Command in Shell-quote](https://github.com/advisories/GHSA-g4rg-993r-mgx7)\n* wh0.github.io: [Exploiting CVE-2021-42740](https://wh0.github.io/2021/10/28/shell-quote-rce-exploiting.html)\n* Yosuke Ota: [no-obscure-range](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-obscure-range.html)\n* Paul Boyd: [The regex \\[,-.\\]](https://pboyd.io/posts/comma-dash-dot/)\n* Common Weakness Enumeration: [CWE-20](https://cwe.mitre.org/data/definitions/20.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "correctness",
+                                        "security",
+                                        "external/cwe/cwe-020"
+                                    ],
+                                    "description": "Overly permissive regular expression ranges match a wider range of characters than intended.\n              This may allow an attacker to bypass a filter or sanitizer.",
+                                    "id": "java/overly-large-range",
+                                    "kind": "problem",
+                                    "name": "Overly permissive regular expression range",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "5.0"
+                                }
+                            },
+                            {
+                                "id": "java/unsafe-deserialization",
+                                "name": "java/unsafe-deserialization",
+                                "shortDescription": {
+                                    "text": "Deserialization of user-controlled data"
+                                },
+                                "fullDescription": {
+                                    "text": "Deserializing user-controlled data may allow attackers to execute arbitrary code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Deserialization of user-controlled data\nDeserializing untrusted data using any deserialization framework that allows the construction of arbitrary serializable objects is easily exploitable and in many cases allows an attacker to execute arbitrary code. Even before a deserialized object is returned to the caller of a deserialization method a lot of code may have been executed, including static initializers, constructors, and finalizers. Automatic deserialization of fields means that an attacker may craft a nested combination of objects on which the executed initialization code may have unforeseen effects, such as the execution of arbitrary code.\n\nThere are many different serialization frameworks. This query currently supports Kryo, XmlDecoder, XStream, SnakeYaml, JYaml, JsonIO, YAMLBeans, HessianBurlap, Castor, Burlap, Jackson, Jabsorb, Jodd JSON, Flexjson, Gson and Java IO serialization through `ObjectInputStream`/`ObjectOutputStream`.\n\n\n## Recommendation\nAvoid deserialization of untrusted data if at all possible. If the architecture permits it then use other formats instead of serialized objects, for example JSON or XML. However, these formats should not be deserialized into complex objects because this provides further opportunities for attack. For example, XML-based deserialization attacks are possible through libraries such as XStream and XmlDecoder.\n\nAlternatively, a tightly controlled whitelist can limit the vulnerability of code, but be aware of the existence of so-called Bypass Gadgets, which can circumvent such protection measures.\n\nRecommendations specific to particular frameworks supported by this query:\n\n**FastJson** - `com.alibaba:fastjson`\n\n* **Secure by Default**: Partially\n* **Recommendation**: Call `com.alibaba.fastjson.parser.ParserConfig#setSafeMode` with the argument `true` before deserializing untrusted data.\n\n\n**FasterXML** - `com.fasterxml.jackson.core:jackson-databind`\n\n* **Secure by Default**: Yes\n* **Recommendation**: Don't call `com.fasterxml.jackson.databind.ObjectMapper#enableDefaultTyping` and don't annotate any object fields with `com.fasterxml.jackson.annotation.JsonTypeInfo` passing either the `CLASS` or `MINIMAL_CLASS` values to the annotation. Read [this guide](https://cowtowncoder.medium.com/jackson-2-10-safe-default-typing-2d018f0ce2ba).\n\n\n**Kryo** - `com.esotericsoftware:kryo` and `com.esotericsoftware:kryo5`\n\n* **Secure by Default**: Yes for `com.esotericsoftware:kryo5` and for `com.esotericsoftware:kryo` &gt;= v5.0.0\n* **Recommendation**: Don't call `com.esotericsoftware.kryo(5).Kryo#setRegistrationRequired` with the argument `false` on any `Kryo` instance that may deserialize untrusted data.\n\n\n**ObjectInputStream** - `Java Standard Library`\n\n* **Secure by Default**: No\n* **Recommendation**: Use a validating input stream, such as `org.apache.commons.io.serialization.ValidatingObjectInputStream`.\n\n\n**SnakeYAML** - `org.yaml:snakeyaml`\n\n* **Secure by Default**: No\n* **Recommendation**: Pass an instance of `org.yaml.snakeyaml.constructor.SafeConstructor` to `org.yaml.snakeyaml.Yaml`'s constructor before using it to deserialize untrusted data.\n\n\n**XML Decoder** - `Standard Java Library`\n\n* **Secure by Default**: No\n* **Recommendation**: Do not use with untrusted user input.\n\n\n\n## Example\nThe following example calls `readObject` directly on an `ObjectInputStream` that is constructed from untrusted data, and is therefore inherently unsafe.\n\n\n```java\npublic MyObject {\n  public int field;\n  MyObject(int field) {\n    this.field = field;\n  }\n}\n\npublic MyObject deserialize(Socket sock) {\n  try(ObjectInputStream in = new ObjectInputStream(sock.getInputStream())) {\n    return (MyObject)in.readObject(); // unsafe\n  }\n}\n\n```\nRewriting the communication protocol to only rely on reading primitive types from the input stream removes the vulnerability.\n\n\n```java\npublic MyObject deserialize(Socket sock) {\n  try(DataInputStream in = new DataInputStream(sock.getInputStream())) {\n    return new MyObject(in.readInt());\n  }\n}\n\n```\n\n## References\n* OWASP vulnerability description: [Deserialization of untrusted data](https://www.owasp.org/index.php/Deserialization_of_untrusted_data).\n* OWASP guidance on deserializing objects: [Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html).\n* Talks by Chris Frohoff &amp; Gabriel Lawrence: [ AppSecCali 2015: Marshalling Pickles - how deserializing objects will ruin your day](http://frohoff.github.io/appseccali-marshalling-pickles/), [OWASP SD: Deserialize My Shorts: Or How I Learned to Start Worrying and Hate Java Object Deserialization](http://frohoff.github.io/owaspsd-deserialize-my-shorts/).\n* Alvaro Muñoz &amp; Christian Schneider, RSAConference 2016: [Serial Killer: Silently Pwning Your Java Endpoints](https://speakerdeck.com/pwntester/serial-killer-silently-pwning-your-java-endpoints).\n* SnakeYaml documentation on deserialization: [SnakeYaml deserialization](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Documentation#markdown-header-loading-yaml).\n* Hessian deserialization and related gadget chains: [Hessian deserialization](https://paper.seebug.org/1137/).\n* Castor and Hessian java deserialization vulnerabilities: [Castor and Hessian deserialization](https://securitylab.github.com/research/hessian-java-deserialization-castor-vulnerabilities/).\n* Remote code execution in JYaml library: [JYaml deserialization](https://www.cybersecurity-help.cz/vdb/SB2020022512).\n* JsonIO deserialization vulnerabilities: [JsonIO deserialization](https://klezvirus.github.io/Advanced-Web-Hacking/Serialisation/).\n* Research by Moritz Bechler: [Java Unmarshaller Security - Turning your data into code execution](https://www.github.com/mbechler/marshalsec/blob/master/marshalsec.pdf?raw=true)\n* Blog posts by the developer of Jackson libraries: [On Jackson CVEs: Don’t Panic — Here is what you need to know](https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062) [Jackson 2.10: Safe Default Typing](https://cowtowncoder.medium.com/jackson-2-10-safe-default-typing-2d018f0ce2ba)\n* Jabsorb documentation on deserialization: [Jabsorb JSON Serializer](https://github.com/Servoy/jabsorb/blob/master/src/org/jabsorb/).\n* Jodd JSON documentation on deserialization: [JoddJson Parser](https://json.jodd.org/parser).\n* RCE in Flexjson: [Flexjson deserialization](https://codewhitesec.blogspot.com/2020/03/liferay-portal-json-vulns.html).\n* Android Intent deserialization vulnerabilities with GSON parser: [Insecure use of JSON parsers](https://blog.oversecured.com/Exploiting-memory-corruption-vulnerabilities-on-Android/#insecure-use-of-json-parsers).\n* Common Weakness Enumeration: [CWE-502](https://cwe.mitre.org/data/definitions/502.html).\n",
+                                    "markdown": "# Deserialization of user-controlled data\nDeserializing untrusted data using any deserialization framework that allows the construction of arbitrary serializable objects is easily exploitable and in many cases allows an attacker to execute arbitrary code. Even before a deserialized object is returned to the caller of a deserialization method a lot of code may have been executed, including static initializers, constructors, and finalizers. Automatic deserialization of fields means that an attacker may craft a nested combination of objects on which the executed initialization code may have unforeseen effects, such as the execution of arbitrary code.\n\nThere are many different serialization frameworks. This query currently supports Kryo, XmlDecoder, XStream, SnakeYaml, JYaml, JsonIO, YAMLBeans, HessianBurlap, Castor, Burlap, Jackson, Jabsorb, Jodd JSON, Flexjson, Gson and Java IO serialization through `ObjectInputStream`/`ObjectOutputStream`.\n\n\n## Recommendation\nAvoid deserialization of untrusted data if at all possible. If the architecture permits it then use other formats instead of serialized objects, for example JSON or XML. However, these formats should not be deserialized into complex objects because this provides further opportunities for attack. For example, XML-based deserialization attacks are possible through libraries such as XStream and XmlDecoder.\n\nAlternatively, a tightly controlled whitelist can limit the vulnerability of code, but be aware of the existence of so-called Bypass Gadgets, which can circumvent such protection measures.\n\nRecommendations specific to particular frameworks supported by this query:\n\n**FastJson** - `com.alibaba:fastjson`\n\n* **Secure by Default**: Partially\n* **Recommendation**: Call `com.alibaba.fastjson.parser.ParserConfig#setSafeMode` with the argument `true` before deserializing untrusted data.\n\n\n**FasterXML** - `com.fasterxml.jackson.core:jackson-databind`\n\n* **Secure by Default**: Yes\n* **Recommendation**: Don't call `com.fasterxml.jackson.databind.ObjectMapper#enableDefaultTyping` and don't annotate any object fields with `com.fasterxml.jackson.annotation.JsonTypeInfo` passing either the `CLASS` or `MINIMAL_CLASS` values to the annotation. Read [this guide](https://cowtowncoder.medium.com/jackson-2-10-safe-default-typing-2d018f0ce2ba).\n\n\n**Kryo** - `com.esotericsoftware:kryo` and `com.esotericsoftware:kryo5`\n\n* **Secure by Default**: Yes for `com.esotericsoftware:kryo5` and for `com.esotericsoftware:kryo` &gt;= v5.0.0\n* **Recommendation**: Don't call `com.esotericsoftware.kryo(5).Kryo#setRegistrationRequired` with the argument `false` on any `Kryo` instance that may deserialize untrusted data.\n\n\n**ObjectInputStream** - `Java Standard Library`\n\n* **Secure by Default**: No\n* **Recommendation**: Use a validating input stream, such as `org.apache.commons.io.serialization.ValidatingObjectInputStream`.\n\n\n**SnakeYAML** - `org.yaml:snakeyaml`\n\n* **Secure by Default**: No\n* **Recommendation**: Pass an instance of `org.yaml.snakeyaml.constructor.SafeConstructor` to `org.yaml.snakeyaml.Yaml`'s constructor before using it to deserialize untrusted data.\n\n\n**XML Decoder** - `Standard Java Library`\n\n* **Secure by Default**: No\n* **Recommendation**: Do not use with untrusted user input.\n\n\n\n## Example\nThe following example calls `readObject` directly on an `ObjectInputStream` that is constructed from untrusted data, and is therefore inherently unsafe.\n\n\n```java\npublic MyObject {\n  public int field;\n  MyObject(int field) {\n    this.field = field;\n  }\n}\n\npublic MyObject deserialize(Socket sock) {\n  try(ObjectInputStream in = new ObjectInputStream(sock.getInputStream())) {\n    return (MyObject)in.readObject(); // unsafe\n  }\n}\n\n```\nRewriting the communication protocol to only rely on reading primitive types from the input stream removes the vulnerability.\n\n\n```java\npublic MyObject deserialize(Socket sock) {\n  try(DataInputStream in = new DataInputStream(sock.getInputStream())) {\n    return new MyObject(in.readInt());\n  }\n}\n\n```\n\n## References\n* OWASP vulnerability description: [Deserialization of untrusted data](https://www.owasp.org/index.php/Deserialization_of_untrusted_data).\n* OWASP guidance on deserializing objects: [Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html).\n* Talks by Chris Frohoff &amp; Gabriel Lawrence: [ AppSecCali 2015: Marshalling Pickles - how deserializing objects will ruin your day](http://frohoff.github.io/appseccali-marshalling-pickles/), [OWASP SD: Deserialize My Shorts: Or How I Learned to Start Worrying and Hate Java Object Deserialization](http://frohoff.github.io/owaspsd-deserialize-my-shorts/).\n* Alvaro Muñoz &amp; Christian Schneider, RSAConference 2016: [Serial Killer: Silently Pwning Your Java Endpoints](https://speakerdeck.com/pwntester/serial-killer-silently-pwning-your-java-endpoints).\n* SnakeYaml documentation on deserialization: [SnakeYaml deserialization](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Documentation#markdown-header-loading-yaml).\n* Hessian deserialization and related gadget chains: [Hessian deserialization](https://paper.seebug.org/1137/).\n* Castor and Hessian java deserialization vulnerabilities: [Castor and Hessian deserialization](https://securitylab.github.com/research/hessian-java-deserialization-castor-vulnerabilities/).\n* Remote code execution in JYaml library: [JYaml deserialization](https://www.cybersecurity-help.cz/vdb/SB2020022512).\n* JsonIO deserialization vulnerabilities: [JsonIO deserialization](https://klezvirus.github.io/Advanced-Web-Hacking/Serialisation/).\n* Research by Moritz Bechler: [Java Unmarshaller Security - Turning your data into code execution](https://www.github.com/mbechler/marshalsec/blob/master/marshalsec.pdf?raw=true)\n* Blog posts by the developer of Jackson libraries: [On Jackson CVEs: Don’t Panic — Here is what you need to know](https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062) [Jackson 2.10: Safe Default Typing](https://cowtowncoder.medium.com/jackson-2-10-safe-default-typing-2d018f0ce2ba)\n* Jabsorb documentation on deserialization: [Jabsorb JSON Serializer](https://github.com/Servoy/jabsorb/blob/master/src/org/jabsorb/).\n* Jodd JSON documentation on deserialization: [JoddJson Parser](https://json.jodd.org/parser).\n* RCE in Flexjson: [Flexjson deserialization](https://codewhitesec.blogspot.com/2020/03/liferay-portal-json-vulns.html).\n* Android Intent deserialization vulnerabilities with GSON parser: [Insecure use of JSON parsers](https://blog.oversecured.com/Exploiting-memory-corruption-vulnerabilities-on-Android/#insecure-use-of-json-parsers).\n* Common Weakness Enumeration: [CWE-502](https://cwe.mitre.org/data/definitions/502.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-502"
+                                    ],
+                                    "description": "Deserializing user-controlled data may allow attackers to\n              execute arbitrary code.",
+                                    "id": "java/unsafe-deserialization",
+                                    "kind": "path-problem",
+                                    "name": "Deserialization of user-controlled data",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/ldap-injection",
+                                "name": "java/ldap-injection",
+                                "shortDescription": {
+                                    "text": "LDAP query built from user-controlled sources"
+                                },
+                                "fullDescription": {
+                                    "text": "Building an LDAP query from user-controlled sources is vulnerable to insertion of malicious LDAP code by the user."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# LDAP query built from user-controlled sources\nIf an LDAP query is built using string concatenation, and the components of the concatenation include user input, a user is likely to be able to run malicious LDAP queries.\n\n\n## Recommendation\nIf user input must be included in an LDAP query, it should be escaped to avoid a malicious user providing special characters that change the meaning of the query. If possible build the LDAP query using framework helper methods, for example from Spring's `LdapQueryBuilder` and `LdapNameBuilder`, instead of string concatenation. Alternatively, escape user input using an appropriate LDAP encoding method, for example: `encodeForLDAP` or `encodeForDN` from OWASP ESAPI, `LdapEncoder.filterEncode` or `LdapEncoder.nameEncode` from Spring LDAP, or `Filter.encodeValue` from UnboundID library.\n\n\n## Example\nIn the following examples, the code accepts an \"organization name\" and a \"username\" from the user, which it uses to query LDAP.\n\nThe first example concatenates the unvalidated and unencoded user input directly into both the DN (Distinguished Name) and the search filter used for the LDAP query. A malicious user could provide special characters to change the meaning of these queries, and search for a completely different set of values. The LDAP query is executed using Java JNDI API.\n\nThe second example uses the OWASP ESAPI library to encode the user values before they are included in the DN and search filters. This ensures the meaning of the query cannot be changed by a malicious user.\n\n\n```java\nimport javax.naming.directory.DirContext;\nimport org.owasp.esapi.Encoder;\nimport org.owasp.esapi.reference.DefaultEncoder;\n\npublic void ldapQueryBad(HttpServletRequest request, DirContext ctx) throws NamingException {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // BAD: User input used in DN (Distinguished Name) without encoding\n  String dn = \"OU=People,O=\" + organizationName;\n\n  // BAD: User input used in search filter without encoding\n  String filter = \"username=\" + userName;\n\n  ctx.search(dn, filter, new SearchControls());\n}\n\npublic void ldapQueryGood(HttpServletRequest request, DirContext ctx) throws NamingException {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // ESAPI encoder\n  Encoder encoder = DefaultEncoder.getInstance();\n\n  // GOOD: Organization name is encoded before being used in DN\n  String safeOrganizationName = encoder.encodeForDN(organizationName);\n  String safeDn = \"OU=People,O=\" + safeOrganizationName;\n\n  // GOOD: User input is encoded before being used in search filter\n  String safeUsername = encoder.encodeForLDAP(username);\n  String safeFilter = \"username=\" + safeUsername;\n  \n  ctx.search(safeDn, safeFilter, new SearchControls());\n}\n```\nThe third example uses Spring `LdapQueryBuilder` to build an LDAP query. In addition to simplifying the building of complex search parameters, it also provides proper escaping of any unsafe characters in search filters. The DN is built using `LdapNameBuilder`, which also provides proper escaping.\n\n\n```java\nimport static org.springframework.ldap.query.LdapQueryBuilder.query;\nimport org.springframework.ldap.support.LdapNameBuilder;\n\npublic void ldapQueryGood(@RequestParam String organizationName, @RequestParam String username) {\n  // GOOD: Organization name is encoded before being used in DN\n  String safeDn = LdapNameBuilder.newInstance()\n    .add(\"O\", organizationName)\n    .add(\"OU=People\")\n    .build().toString();\n\n  // GOOD: User input is encoded before being used in search filter\n  LdapQuery query = query()\n    .base(safeDn)\n    .where(\"username\").is(username);\n\n  ldapTemplate.search(query, new AttributeCheckAttributesMapper());\n}\n```\nThe fourth example uses `UnboundID` classes, `Filter` and `DN`, to construct a safe filter and base DN.\n\n\n```java\nimport com.unboundid.ldap.sdk.LDAPConnection;\nimport com.unboundid.ldap.sdk.DN;\nimport com.unboundid.ldap.sdk.RDN;\nimport com.unboundid.ldap.sdk.Filter;\n\npublic void ldapQueryGood(HttpServletRequest request, LDAPConnection c) {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // GOOD: Organization name is encoded before being used in DN\n  DN safeDn = new DN(new RDN(\"OU\", \"People\"), new RDN(\"O\", organizationName));\n\n  // GOOD: User input is encoded before being used in search filter\n  Filter safeFilter = Filter.createEqualityFilter(\"username\", username);\n  \n  c.search(safeDn.toString(), SearchScope.ONE, safeFilter);\n}\n```\nThe fifth example shows how to build a safe filter and DN using the Apache LDAP API.\n\n\n```java\nimport org.apache.directory.ldap.client.api.LdapConnection;\nimport org.apache.directory.api.ldap.model.name.Dn;\nimport org.apache.directory.api.ldap.model.name.Rdn;\nimport org.apache.directory.api.ldap.model.message.SearchRequest;\nimport org.apache.directory.api.ldap.model.message.SearchRequestImpl;\nimport static org.apache.directory.ldap.client.api.search.FilterBuilder.equal;\n\npublic void ldapQueryGood(HttpServletRequest request, LdapConnection c) {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // GOOD: Organization name is encoded before being used in DN\n  Dn safeDn = new Dn(new Rdn(\"OU\", \"People\"), new Rdn(\"O\", organizationName));\n\n  // GOOD: User input is encoded before being used in search filter\n  String safeFilter = equal(\"username\", username);\n  \n  SearchRequest searchRequest = new SearchRequestImpl();\n  searchRequest.setBase(safeDn);\n  searchRequest.setFilter(safeFilter);\n  c.search(searchRequest);\n}\n```\n\n## References\n* OWASP: [LDAP Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html).\n* OWASP ESAPI: [OWASP ESAPI](https://owasp.org/www-project-enterprise-security-api/).\n* Spring LdapQueryBuilder doc: [LdapQueryBuilder](https://docs.spring.io/spring-ldap/docs/current/apidocs/org/springframework/ldap/query/LdapQueryBuilder.html).\n* Spring LdapNameBuilder doc: [LdapNameBuilder](https://docs.spring.io/spring-ldap/docs/current/apidocs/org/springframework/ldap/support/LdapNameBuilder.html).\n* UnboundID: [Understanding and Defending Against LDAP Injection Attacks](https://ldap.com/2018/05/04/understanding-and-defending-against-ldap-injection-attacks/).\n* Common Weakness Enumeration: [CWE-90](https://cwe.mitre.org/data/definitions/90.html).\n",
+                                    "markdown": "# LDAP query built from user-controlled sources\nIf an LDAP query is built using string concatenation, and the components of the concatenation include user input, a user is likely to be able to run malicious LDAP queries.\n\n\n## Recommendation\nIf user input must be included in an LDAP query, it should be escaped to avoid a malicious user providing special characters that change the meaning of the query. If possible build the LDAP query using framework helper methods, for example from Spring's `LdapQueryBuilder` and `LdapNameBuilder`, instead of string concatenation. Alternatively, escape user input using an appropriate LDAP encoding method, for example: `encodeForLDAP` or `encodeForDN` from OWASP ESAPI, `LdapEncoder.filterEncode` or `LdapEncoder.nameEncode` from Spring LDAP, or `Filter.encodeValue` from UnboundID library.\n\n\n## Example\nIn the following examples, the code accepts an \"organization name\" and a \"username\" from the user, which it uses to query LDAP.\n\nThe first example concatenates the unvalidated and unencoded user input directly into both the DN (Distinguished Name) and the search filter used for the LDAP query. A malicious user could provide special characters to change the meaning of these queries, and search for a completely different set of values. The LDAP query is executed using Java JNDI API.\n\nThe second example uses the OWASP ESAPI library to encode the user values before they are included in the DN and search filters. This ensures the meaning of the query cannot be changed by a malicious user.\n\n\n```java\nimport javax.naming.directory.DirContext;\nimport org.owasp.esapi.Encoder;\nimport org.owasp.esapi.reference.DefaultEncoder;\n\npublic void ldapQueryBad(HttpServletRequest request, DirContext ctx) throws NamingException {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // BAD: User input used in DN (Distinguished Name) without encoding\n  String dn = \"OU=People,O=\" + organizationName;\n\n  // BAD: User input used in search filter without encoding\n  String filter = \"username=\" + userName;\n\n  ctx.search(dn, filter, new SearchControls());\n}\n\npublic void ldapQueryGood(HttpServletRequest request, DirContext ctx) throws NamingException {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // ESAPI encoder\n  Encoder encoder = DefaultEncoder.getInstance();\n\n  // GOOD: Organization name is encoded before being used in DN\n  String safeOrganizationName = encoder.encodeForDN(organizationName);\n  String safeDn = \"OU=People,O=\" + safeOrganizationName;\n\n  // GOOD: User input is encoded before being used in search filter\n  String safeUsername = encoder.encodeForLDAP(username);\n  String safeFilter = \"username=\" + safeUsername;\n  \n  ctx.search(safeDn, safeFilter, new SearchControls());\n}\n```\nThe third example uses Spring `LdapQueryBuilder` to build an LDAP query. In addition to simplifying the building of complex search parameters, it also provides proper escaping of any unsafe characters in search filters. The DN is built using `LdapNameBuilder`, which also provides proper escaping.\n\n\n```java\nimport static org.springframework.ldap.query.LdapQueryBuilder.query;\nimport org.springframework.ldap.support.LdapNameBuilder;\n\npublic void ldapQueryGood(@RequestParam String organizationName, @RequestParam String username) {\n  // GOOD: Organization name is encoded before being used in DN\n  String safeDn = LdapNameBuilder.newInstance()\n    .add(\"O\", organizationName)\n    .add(\"OU=People\")\n    .build().toString();\n\n  // GOOD: User input is encoded before being used in search filter\n  LdapQuery query = query()\n    .base(safeDn)\n    .where(\"username\").is(username);\n\n  ldapTemplate.search(query, new AttributeCheckAttributesMapper());\n}\n```\nThe fourth example uses `UnboundID` classes, `Filter` and `DN`, to construct a safe filter and base DN.\n\n\n```java\nimport com.unboundid.ldap.sdk.LDAPConnection;\nimport com.unboundid.ldap.sdk.DN;\nimport com.unboundid.ldap.sdk.RDN;\nimport com.unboundid.ldap.sdk.Filter;\n\npublic void ldapQueryGood(HttpServletRequest request, LDAPConnection c) {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // GOOD: Organization name is encoded before being used in DN\n  DN safeDn = new DN(new RDN(\"OU\", \"People\"), new RDN(\"O\", organizationName));\n\n  // GOOD: User input is encoded before being used in search filter\n  Filter safeFilter = Filter.createEqualityFilter(\"username\", username);\n  \n  c.search(safeDn.toString(), SearchScope.ONE, safeFilter);\n}\n```\nThe fifth example shows how to build a safe filter and DN using the Apache LDAP API.\n\n\n```java\nimport org.apache.directory.ldap.client.api.LdapConnection;\nimport org.apache.directory.api.ldap.model.name.Dn;\nimport org.apache.directory.api.ldap.model.name.Rdn;\nimport org.apache.directory.api.ldap.model.message.SearchRequest;\nimport org.apache.directory.api.ldap.model.message.SearchRequestImpl;\nimport static org.apache.directory.ldap.client.api.search.FilterBuilder.equal;\n\npublic void ldapQueryGood(HttpServletRequest request, LdapConnection c) {\n  String organizationName = request.getParameter(\"organization_name\");\n  String username = request.getParameter(\"username\");\n\n  // GOOD: Organization name is encoded before being used in DN\n  Dn safeDn = new Dn(new Rdn(\"OU\", \"People\"), new Rdn(\"O\", organizationName));\n\n  // GOOD: User input is encoded before being used in search filter\n  String safeFilter = equal(\"username\", username);\n  \n  SearchRequest searchRequest = new SearchRequestImpl();\n  searchRequest.setBase(safeDn);\n  searchRequest.setFilter(safeFilter);\n  c.search(searchRequest);\n}\n```\n\n## References\n* OWASP: [LDAP Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html).\n* OWASP ESAPI: [OWASP ESAPI](https://owasp.org/www-project-enterprise-security-api/).\n* Spring LdapQueryBuilder doc: [LdapQueryBuilder](https://docs.spring.io/spring-ldap/docs/current/apidocs/org/springframework/ldap/query/LdapQueryBuilder.html).\n* Spring LdapNameBuilder doc: [LdapNameBuilder](https://docs.spring.io/spring-ldap/docs/current/apidocs/org/springframework/ldap/support/LdapNameBuilder.html).\n* UnboundID: [Understanding and Defending Against LDAP Injection Attacks](https://ldap.com/2018/05/04/understanding-and-defending-against-ldap-injection-attacks/).\n* Common Weakness Enumeration: [CWE-90](https://cwe.mitre.org/data/definitions/90.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-090"
+                                    ],
+                                    "description": "Building an LDAP query from user-controlled sources is vulnerable to insertion of\n              malicious LDAP code by the user.",
+                                    "id": "java/ldap-injection",
+                                    "kind": "path-problem",
+                                    "name": "LDAP query built from user-controlled sources",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/android/implicit-pendingintents",
+                                "name": "java/android/implicit-pendingintents",
+                                "shortDescription": {
+                                    "text": "Use of implicit PendingIntents"
+                                },
+                                "fullDescription": {
+                                    "text": "Sending an implicit and mutable 'PendingIntent' to an unspecified third party component may provide an attacker with access to internal components of the application or cause other unintended effects."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Use of implicit PendingIntents\nA `PendingIntent` is used to wrap an `Intent` that will be supplied and executed by another application. When the `Intent` is executed, it behaves as if it were run directly by the supplying application, using the privileges of that application.\n\nIf a `PendingIntent` is configured to be mutable, the fields of its internal `Intent` can be changed by the receiving application if they were not previously set. This means that a mutable `PendingIntent` that has not defined a destination component (that is, an implicit `PendingIntent`) can be altered to execute an arbitrary action with the privileges of the application that created it.\n\nA malicious application can access an implicit `PendingIntent` as follows:\n\n* It is wrapped and sent as an extra of another implicit `Intent`.\n* It is sent as the action of a `Slide`.\n* It is sent as the action of a `Notification`.\n\n\nOn gaining access, the attacker can modify the underlying `Intent` and execute an arbitrary action with elevated privileges. This could give the malicious application access to private components of the victim application, or the ability to perform actions without having the necessary permissions.\n\n\n## Recommendation\nAvoid creating implicit `PendingIntent`s. This means that the underlying `Intent` should always have an explicit destination component.\n\nWhen you add the `PendingIntent` as an extra of another `Intent`, make sure that this second `Intent` also has an explicit destination component, so that it is not delivered to untrusted applications.\n\nCreate the `PendingIntent` using the flag `FLAG_IMMUTABLE` whenever possible, to prevent the destination component from modifying empty fields of the underlying `Intent`.\n\n\n## Example\nIn the following examples, a `PendingIntent` is created and wrapped as an extra of another `Intent`.\n\nIn the first example, both the `PendingIntent` and the `Intent` it is wrapped in are implicit, making them vulnerable to attack.\n\nIn the second example, the issue is avoided by adding explicit destination components to the `PendingIntent` and the wrapping `Intent`.\n\nThe third example uses the `FLAG_IMMUTABLE` flag to prevent the underlying `Intent` from being modified by the destination component.\n\n\n```java\nimport android.app.Activity;\nimport android.app.PendingIntent;\nimport android.content.Intent;\nimport android.os.Bundle;\n\npublic class ImplicitPendingIntents extends Activity {\n\n\tpublic void onCreate(Bundle savedInstance) {\n\t\t{\n\t\t\t// BAD: an implicit Intent is used to create a PendingIntent.\n\t\t\t// The PendingIntent is then added to another implicit Intent\n\t\t\t// and started.\n\t\t\tIntent baseIntent = new Intent();\n\t\t\tPendingIntent pi =\n\t\t\t\t\tPendingIntent.getActivity(this, 0, baseIntent, PendingIntent.FLAG_ONE_SHOT);\n\t\t\tIntent fwdIntent = new Intent(\"SOME_ACTION\");\n\t\t\tfwdIntent.putExtra(\"fwdIntent\", pi);\n\t\t\tsendBroadcast(fwdIntent);\n\t\t}\n\n\t\t{\n\t\t\t// GOOD: both the PendingIntent and the wrapping Intent are explicit.\n\t\t\tIntent safeIntent = new Intent(this, AnotherActivity.class);\n\t\t\tPendingIntent pi =\n\t\t\t\t\tPendingIntent.getActivity(this, 0, safeIntent, PendingIntent.FLAG_ONE_SHOT);\n\t\t\tIntent fwdIntent = new Intent();\n\t\t\tfwdIntent.setClassName(\"destination.package\", \"DestinationClass\");\n\t\t\tfwdIntent.putExtra(\"fwdIntent\", pi);\n\t\t\tstartActivity(fwdIntent);\n\t\t}\n\n\t\t{\n\t\t\t// GOOD: The PendingIntent is created with FLAG_IMMUTABLE.\n\t\t\tIntent baseIntent = new Intent(\"SOME_ACTION\");\n\t\t\tPendingIntent pi =\n\t\t\t\t\tPendingIntent.getActivity(this, 0, baseIntent, PendingIntent.FLAG_IMMUTABLE);\n\t\t\tIntent fwdIntent = new Intent();\n\t\t\tfwdIntent.setClassName(\"destination.package\", \"DestinationClass\");\n\t\t\tfwdIntent.putExtra(\"fwdIntent\", pi);\n\t\t\tstartActivity(fwdIntent);\n\t\t}\n\t}\n}\n\n```\n\n## References\n* Google Help: [ Remediation for Implicit PendingIntent Vulnerability ](https://support.google.com/faqs/answer/10437428?hl=en)\n* University of Potsdam: [ PIAnalyzer: A precise approach for PendingIntent vulnerability analysis ](https://www.cs.uni-potsdam.de/se/papers/esorics18.pdf)\n* Common Weakness Enumeration: [CWE-927](https://cwe.mitre.org/data/definitions/927.html).\n",
+                                    "markdown": "# Use of implicit PendingIntents\nA `PendingIntent` is used to wrap an `Intent` that will be supplied and executed by another application. When the `Intent` is executed, it behaves as if it were run directly by the supplying application, using the privileges of that application.\n\nIf a `PendingIntent` is configured to be mutable, the fields of its internal `Intent` can be changed by the receiving application if they were not previously set. This means that a mutable `PendingIntent` that has not defined a destination component (that is, an implicit `PendingIntent`) can be altered to execute an arbitrary action with the privileges of the application that created it.\n\nA malicious application can access an implicit `PendingIntent` as follows:\n\n* It is wrapped and sent as an extra of another implicit `Intent`.\n* It is sent as the action of a `Slide`.\n* It is sent as the action of a `Notification`.\n\n\nOn gaining access, the attacker can modify the underlying `Intent` and execute an arbitrary action with elevated privileges. This could give the malicious application access to private components of the victim application, or the ability to perform actions without having the necessary permissions.\n\n\n## Recommendation\nAvoid creating implicit `PendingIntent`s. This means that the underlying `Intent` should always have an explicit destination component.\n\nWhen you add the `PendingIntent` as an extra of another `Intent`, make sure that this second `Intent` also has an explicit destination component, so that it is not delivered to untrusted applications.\n\nCreate the `PendingIntent` using the flag `FLAG_IMMUTABLE` whenever possible, to prevent the destination component from modifying empty fields of the underlying `Intent`.\n\n\n## Example\nIn the following examples, a `PendingIntent` is created and wrapped as an extra of another `Intent`.\n\nIn the first example, both the `PendingIntent` and the `Intent` it is wrapped in are implicit, making them vulnerable to attack.\n\nIn the second example, the issue is avoided by adding explicit destination components to the `PendingIntent` and the wrapping `Intent`.\n\nThe third example uses the `FLAG_IMMUTABLE` flag to prevent the underlying `Intent` from being modified by the destination component.\n\n\n```java\nimport android.app.Activity;\nimport android.app.PendingIntent;\nimport android.content.Intent;\nimport android.os.Bundle;\n\npublic class ImplicitPendingIntents extends Activity {\n\n\tpublic void onCreate(Bundle savedInstance) {\n\t\t{\n\t\t\t// BAD: an implicit Intent is used to create a PendingIntent.\n\t\t\t// The PendingIntent is then added to another implicit Intent\n\t\t\t// and started.\n\t\t\tIntent baseIntent = new Intent();\n\t\t\tPendingIntent pi =\n\t\t\t\t\tPendingIntent.getActivity(this, 0, baseIntent, PendingIntent.FLAG_ONE_SHOT);\n\t\t\tIntent fwdIntent = new Intent(\"SOME_ACTION\");\n\t\t\tfwdIntent.putExtra(\"fwdIntent\", pi);\n\t\t\tsendBroadcast(fwdIntent);\n\t\t}\n\n\t\t{\n\t\t\t// GOOD: both the PendingIntent and the wrapping Intent are explicit.\n\t\t\tIntent safeIntent = new Intent(this, AnotherActivity.class);\n\t\t\tPendingIntent pi =\n\t\t\t\t\tPendingIntent.getActivity(this, 0, safeIntent, PendingIntent.FLAG_ONE_SHOT);\n\t\t\tIntent fwdIntent = new Intent();\n\t\t\tfwdIntent.setClassName(\"destination.package\", \"DestinationClass\");\n\t\t\tfwdIntent.putExtra(\"fwdIntent\", pi);\n\t\t\tstartActivity(fwdIntent);\n\t\t}\n\n\t\t{\n\t\t\t// GOOD: The PendingIntent is created with FLAG_IMMUTABLE.\n\t\t\tIntent baseIntent = new Intent(\"SOME_ACTION\");\n\t\t\tPendingIntent pi =\n\t\t\t\t\tPendingIntent.getActivity(this, 0, baseIntent, PendingIntent.FLAG_IMMUTABLE);\n\t\t\tIntent fwdIntent = new Intent();\n\t\t\tfwdIntent.setClassName(\"destination.package\", \"DestinationClass\");\n\t\t\tfwdIntent.putExtra(\"fwdIntent\", pi);\n\t\t\tstartActivity(fwdIntent);\n\t\t}\n\t}\n}\n\n```\n\n## References\n* Google Help: [ Remediation for Implicit PendingIntent Vulnerability ](https://support.google.com/faqs/answer/10437428?hl=en)\n* University of Potsdam: [ PIAnalyzer: A precise approach for PendingIntent vulnerability analysis ](https://www.cs.uni-potsdam.de/se/papers/esorics18.pdf)\n* Common Weakness Enumeration: [CWE-927](https://cwe.mitre.org/data/definitions/927.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-927"
+                                    ],
+                                    "description": "Sending an implicit and mutable 'PendingIntent' to an unspecified third party\n              component may provide an attacker with access to internal components of the\n              application or cause other unintended effects.",
+                                    "id": "java/android/implicit-pendingintents",
+                                    "kind": "path-problem",
+                                    "name": "Use of implicit PendingIntents",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "8.2"
+                                }
+                            },
+                            {
+                                "id": "java/improper-webview-certificate-validation",
+                                "name": "java/improper-webview-certificate-validation",
+                                "shortDescription": {
+                                    "text": "Android `WebView` that accepts all certificates"
+                                },
+                                "fullDescription": {
+                                    "text": "Trusting all certificates allows an attacker to perform a machine-in-the-middle attack."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Android `WebView` that accepts all certificates\nIf the `onReceivedSslError` method of an Android `WebViewClient` always calls `proceed` on the given `SslErrorHandler`, it trusts any certificate. This allows an attacker to perform a machine-in-the-middle attack against the application, therefore breaking any security Transport Layer Security (TLS) gives.\n\nAn attack might look like this:\n\n1. The vulnerable application connects to `https://example.com`.\n1. The attacker intercepts this connection and presents a valid, self-signed certificate for `https://example.com`.\n1. The vulnerable application calls the `onReceivedSslError` method to check whether it should trust the certificate.\n1. The `onReceivedSslError` method of your `WebViewClient` calls `SslErrorHandler.proceed`.\n1. The vulnerable application accepts the certificate and proceeds with the connection since your `WevViewClient` trusted it by proceeding.\n1. The attacker can now read the data your application sends to `https://example.com` and/or alter its replies while the application thinks the connection is secure.\n\n## Recommendation\nDo not use a call `SslerrorHandler.proceed` unconditionally. If you have to use a self-signed certificate, only accept that certificate, not all certificates.\n\n\n## Example\nIn the first (bad) example, the `WebViewClient` trusts all certificates by always calling `SslErrorHandler.proceed`. In the second (good) example, only certificates signed by a certain public key are accepted.\n\n\n```java\nclass Bad extends WebViewClient {\n    // BAD: All certificates are trusted.\n    public void onReceivedSslError (WebView view, SslErrorHandler handler, SslError error) { // $hasResult\n        handler.proceed(); \n    }\n}\n\nclass Good extends WebViewClient {\n    PublicKey myPubKey = ...;\n\n    // GOOD: Only certificates signed by a certain public key are trusted.\n    public void onReceivedSslError (WebView view, SslErrorHandler handler, SslError error) { // $hasResult\n        try {\n            X509Certificate cert = error.getCertificate().getX509Certificate();\n            cert.verify(this.myPubKey);\n            handler.proceed();\n        }\n        catch (CertificateException|NoSuchAlgorithmException|InvalidKeyException|NoSuchProviderException|SignatureException e) {\n            handler.cancel();\n        }\n    }    \n}\n```\n\n## References\n* [WebViewClient.onReceivedSslError documentation](https://developer.android.com/reference/android/webkit/WebViewClient?hl=en#onReceivedSslError(android.webkit.WebView,%20android.webkit.SslErrorHandler,%20android.net.http.SslError)).\n* Common Weakness Enumeration: [CWE-295](https://cwe.mitre.org/data/definitions/295.html).\n",
+                                    "markdown": "# Android `WebView` that accepts all certificates\nIf the `onReceivedSslError` method of an Android `WebViewClient` always calls `proceed` on the given `SslErrorHandler`, it trusts any certificate. This allows an attacker to perform a machine-in-the-middle attack against the application, therefore breaking any security Transport Layer Security (TLS) gives.\n\nAn attack might look like this:\n\n1. The vulnerable application connects to `https://example.com`.\n1. The attacker intercepts this connection and presents a valid, self-signed certificate for `https://example.com`.\n1. The vulnerable application calls the `onReceivedSslError` method to check whether it should trust the certificate.\n1. The `onReceivedSslError` method of your `WebViewClient` calls `SslErrorHandler.proceed`.\n1. The vulnerable application accepts the certificate and proceeds with the connection since your `WevViewClient` trusted it by proceeding.\n1. The attacker can now read the data your application sends to `https://example.com` and/or alter its replies while the application thinks the connection is secure.\n\n## Recommendation\nDo not use a call `SslerrorHandler.proceed` unconditionally. If you have to use a self-signed certificate, only accept that certificate, not all certificates.\n\n\n## Example\nIn the first (bad) example, the `WebViewClient` trusts all certificates by always calling `SslErrorHandler.proceed`. In the second (good) example, only certificates signed by a certain public key are accepted.\n\n\n```java\nclass Bad extends WebViewClient {\n    // BAD: All certificates are trusted.\n    public void onReceivedSslError (WebView view, SslErrorHandler handler, SslError error) { // $hasResult\n        handler.proceed(); \n    }\n}\n\nclass Good extends WebViewClient {\n    PublicKey myPubKey = ...;\n\n    // GOOD: Only certificates signed by a certain public key are trusted.\n    public void onReceivedSslError (WebView view, SslErrorHandler handler, SslError error) { // $hasResult\n        try {\n            X509Certificate cert = error.getCertificate().getX509Certificate();\n            cert.verify(this.myPubKey);\n            handler.proceed();\n        }\n        catch (CertificateException|NoSuchAlgorithmException|InvalidKeyException|NoSuchProviderException|SignatureException e) {\n            handler.cancel();\n        }\n    }    \n}\n```\n\n## References\n* [WebViewClient.onReceivedSslError documentation](https://developer.android.com/reference/android/webkit/WebViewClient?hl=en#onReceivedSslError(android.webkit.WebView,%20android.webkit.SslErrorHandler,%20android.net.http.SslError)).\n* Common Weakness Enumeration: [CWE-295](https://cwe.mitre.org/data/definitions/295.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-295"
+                                    ],
+                                    "description": "Trusting all certificates allows an attacker to perform a machine-in-the-middle attack.",
+                                    "id": "java/improper-webview-certificate-validation",
+                                    "kind": "problem",
+                                    "name": "Android `WebView` that accepts all certificates",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/insecure-trustmanager",
+                                "name": "java/insecure-trustmanager",
+                                "shortDescription": {
+                                    "text": "`TrustManager` that accepts all certificates"
+                                },
+                                "fullDescription": {
+                                    "text": "Trusting all certificates allows an attacker to perform a machine-in-the-middle attack."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# `TrustManager` that accepts all certificates\nIf the `checkServerTrusted` method of a `TrustManager` never throws a `CertificateException`, it trusts every certificate. This allows an attacker to perform a machine-in-the-middle attack against the application, therefore breaking any security Transport Layer Security (TLS) gives.\n\nAn attack might look like this:\n\n1. The vulnerable program connects to `https://example.com`.\n1. The attacker intercepts this connection and presents a valid, self-signed certificate for `https://example.com`.\n1. The vulnerable program calls the `checkServerTrusted` method to check whether it should trust the certificate.\n1. The `checkServerTrusted` method of your `TrustManager` does not throw a `CertificateException`.\n1. The vulnerable program accepts the certificate and proceeds with the connection since your `TrustManager` implicitly trusted it by not throwing an exception.\n1. The attacker can now read the data your program sends to `https://example.com` and/or alter its replies while the program thinks the connection is secure.\n\n## Recommendation\nDo not use a custom `TrustManager` that trusts any certificate. If you have to use a self-signed certificate, don't trust every certificate, but instead only trust this specific certificate. See below for an example of how to do this.\n\n\n## Example\nIn the first (bad) example, the `TrustManager` never throws a `CertificateException` and therefore implicitly trusts any certificate. This allows an attacker to perform a machine-in-the-middle attack. In the second (good) example, the self-signed certificate that should be trusted is loaded into a `KeyStore`. This explicitly defines the certificate as trusted and there is no need to create a custom `TrustManager`.\n\n\n```java\npublic static void main(String[] args) throws Exception {\n    {\n        class InsecureTrustManager implements X509TrustManager {\n            @Override\n            public X509Certificate[] getAcceptedIssuers() {\n                return null;\n            }\n\n            @Override\n            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {\n                // BAD: Does not verify the certificate chain, allowing any certificate.\n            }\n\n            @Override\n            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {\n\n            }\n        }\n        SSLContext context = SSLContext.getInstance(\"TLS\");\n        TrustManager[] trustManager = new TrustManager[] { new InsecureTrustManager() };\n        context.init(null, trustManager, null);\n    }\n    {\n        SSLContext context = SSLContext.getInstance(\"TLS\");\n        File certificateFile = new File(\"path/to/self-signed-certificate\");\n        // Create a `KeyStore` with default type\n        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());\n        // `keyStore` is initially empty\n        keyStore.load(null, null);\n        X509Certificate generatedCertificate;\n        try (InputStream cert = new FileInputStream(certificateFile)) {\n            generatedCertificate = (X509Certificate) CertificateFactory.getInstance(\"X509\")\n                    .generateCertificate(cert);\n        }\n        // Add the self-signed certificate to the key store\n        keyStore.setCertificateEntry(certificateFile.getName(), generatedCertificate);\n        // Get default `TrustManagerFactory`\n        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());\n        // Use it with our key store that trusts our self-signed certificate\n        tmf.init(keyStore);\n        TrustManager[] trustManagers = tmf.getTrustManagers();\n        context.init(null, trustManagers, null);\n        // GOOD, we are not using a custom `TrustManager` but instead have\n        // added the self-signed certificate we want to trust to the key\n        // store. Note, the `trustManagers` will **only** trust this one\n        // certificate.\n        \n        URL url = new URL(\"https://self-signed.badssl.com/\");\n        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();\n        conn.setSSLSocketFactory(context.getSocketFactory());\n    }\n}\n\n```\n\n## References\n* Android Developers: [Security with HTTPS and SSL](https://developer.android.com/training/articles/security-ssl).\n* Common Weakness Enumeration: [CWE-295](https://cwe.mitre.org/data/definitions/295.html).\n",
+                                    "markdown": "# `TrustManager` that accepts all certificates\nIf the `checkServerTrusted` method of a `TrustManager` never throws a `CertificateException`, it trusts every certificate. This allows an attacker to perform a machine-in-the-middle attack against the application, therefore breaking any security Transport Layer Security (TLS) gives.\n\nAn attack might look like this:\n\n1. The vulnerable program connects to `https://example.com`.\n1. The attacker intercepts this connection and presents a valid, self-signed certificate for `https://example.com`.\n1. The vulnerable program calls the `checkServerTrusted` method to check whether it should trust the certificate.\n1. The `checkServerTrusted` method of your `TrustManager` does not throw a `CertificateException`.\n1. The vulnerable program accepts the certificate and proceeds with the connection since your `TrustManager` implicitly trusted it by not throwing an exception.\n1. The attacker can now read the data your program sends to `https://example.com` and/or alter its replies while the program thinks the connection is secure.\n\n## Recommendation\nDo not use a custom `TrustManager` that trusts any certificate. If you have to use a self-signed certificate, don't trust every certificate, but instead only trust this specific certificate. See below for an example of how to do this.\n\n\n## Example\nIn the first (bad) example, the `TrustManager` never throws a `CertificateException` and therefore implicitly trusts any certificate. This allows an attacker to perform a machine-in-the-middle attack. In the second (good) example, the self-signed certificate that should be trusted is loaded into a `KeyStore`. This explicitly defines the certificate as trusted and there is no need to create a custom `TrustManager`.\n\n\n```java\npublic static void main(String[] args) throws Exception {\n    {\n        class InsecureTrustManager implements X509TrustManager {\n            @Override\n            public X509Certificate[] getAcceptedIssuers() {\n                return null;\n            }\n\n            @Override\n            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {\n                // BAD: Does not verify the certificate chain, allowing any certificate.\n            }\n\n            @Override\n            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {\n\n            }\n        }\n        SSLContext context = SSLContext.getInstance(\"TLS\");\n        TrustManager[] trustManager = new TrustManager[] { new InsecureTrustManager() };\n        context.init(null, trustManager, null);\n    }\n    {\n        SSLContext context = SSLContext.getInstance(\"TLS\");\n        File certificateFile = new File(\"path/to/self-signed-certificate\");\n        // Create a `KeyStore` with default type\n        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());\n        // `keyStore` is initially empty\n        keyStore.load(null, null);\n        X509Certificate generatedCertificate;\n        try (InputStream cert = new FileInputStream(certificateFile)) {\n            generatedCertificate = (X509Certificate) CertificateFactory.getInstance(\"X509\")\n                    .generateCertificate(cert);\n        }\n        // Add the self-signed certificate to the key store\n        keyStore.setCertificateEntry(certificateFile.getName(), generatedCertificate);\n        // Get default `TrustManagerFactory`\n        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());\n        // Use it with our key store that trusts our self-signed certificate\n        tmf.init(keyStore);\n        TrustManager[] trustManagers = tmf.getTrustManagers();\n        context.init(null, trustManagers, null);\n        // GOOD, we are not using a custom `TrustManager` but instead have\n        // added the self-signed certificate we want to trust to the key\n        // store. Note, the `trustManagers` will **only** trust this one\n        // certificate.\n        \n        URL url = new URL(\"https://self-signed.badssl.com/\");\n        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();\n        conn.setSSLSocketFactory(context.getSocketFactory());\n    }\n}\n\n```\n\n## References\n* Android Developers: [Security with HTTPS and SSL](https://developer.android.com/training/articles/security-ssl).\n* Common Weakness Enumeration: [CWE-295](https://cwe.mitre.org/data/definitions/295.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-295"
+                                    ],
+                                    "description": "Trusting all certificates allows an attacker to perform a machine-in-the-middle attack.",
+                                    "id": "java/insecure-trustmanager",
+                                    "kind": "path-problem",
+                                    "name": "`TrustManager` that accepts all certificates",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/android/fragment-injection",
+                                "name": "java/android/fragment-injection",
+                                "shortDescription": {
+                                    "text": "Android fragment injection"
+                                },
+                                "fullDescription": {
+                                    "text": "Instantiating an Android fragment from a user-provided value may allow a malicious application to bypass access controls, exposing the application to unintended effects."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Android fragment injection\nWhen fragments are instantiated with externally provided names, this exposes any exported activity that dynamically creates and hosts the fragment to fragment injection. A malicious application could provide the name of an arbitrary fragment, even one not designed to be externally accessible, and inject it into the activity. This can bypass access controls and expose the application to unintended effects.\n\nFragments are reusable parts of an Android application's user interface. Even though a fragment controls its own lifecycle and layout, and handles its input events, it cannot exist on its own: it must be hosted either by an activity or another fragment. This means that, normally, a fragment will be accessible by third-party applications (that is, exported) only if its hosting activity is itself exported.\n\n\n## Recommendation\nIn general, do not instantiate classes (including fragments) with user-provided names unless the name has been properly validated. Also, if an exported activity is extending the `PreferenceActivity` class, make sure that the `isValidFragment` method is overriden and only returns `true` when the provided `fragmentName` points to an intended fragment.\n\n\n## Example\nThe following example shows two cases: in the first one, untrusted data is used to instantiate and add a fragment to an activity, while in the second one, a fragment is safely added with a static name.\n\n\n```java\npublic class MyActivity extends FragmentActivity {\n\n    @Override\n    protected void onCreate(Bundle savedInstance) {\n        try {\n            super.onCreate(savedInstance);\n            // BAD: Fragment instantiated from user input without validation\n            {\n                String fName = getIntent().getStringExtra(\"fragmentName\");\n                getFragmentManager().beginTransaction().replace(com.android.internal.R.id.prefs,\n                        Fragment.instantiate(this, fName, null)).commit();\n            }\n            // GOOD: Fragment instantiated statically\n            {\n                getFragmentManager().beginTransaction()\n                        .replace(com.android.internal.R.id.prefs, new MyFragment()).commit();\n            }\n        } catch (Exception e) {\n        }\n    }\n\n}\n\n```\nThe next example shows two activities that extend `PreferenceActivity`. The first activity overrides `isValidFragment`, but it wrongly returns `true` unconditionally. The second activity correctly overrides `isValidFragment` so that it only returns `true` when `fragmentName` is a trusted fragment name.\n\n\n```java\nclass UnsafeActivity extends PreferenceActivity {\n\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // BAD: any Fragment name can be provided.\n        return true;\n    }\n}\n\n\nclass SafeActivity extends PreferenceActivity {\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // Good: only trusted Fragment names are allowed.\n        return SafeFragment1.class.getName().equals(fragmentName)\n                || SafeFragment2.class.getName().equals(fragmentName)\n                || SafeFragment3.class.getName().equals(fragmentName);\n    }\n\n}\n\n\n```\n\n## References\n* Google Help: [How to fix Fragment Injection vulnerability](https://support.google.com/faqs/answer/7188427?hl=en).\n* IBM Security Systems: [Android collapses into Fragments](https://securityintelligence.com/wp-content/uploads/2013/12/android-collapses-into-fragments.pdf).\n* Android Developers: [Fragments](https://developer.android.com/guide/fragments)\n* Common Weakness Enumeration: [CWE-470](https://cwe.mitre.org/data/definitions/470.html).\n",
+                                    "markdown": "# Android fragment injection\nWhen fragments are instantiated with externally provided names, this exposes any exported activity that dynamically creates and hosts the fragment to fragment injection. A malicious application could provide the name of an arbitrary fragment, even one not designed to be externally accessible, and inject it into the activity. This can bypass access controls and expose the application to unintended effects.\n\nFragments are reusable parts of an Android application's user interface. Even though a fragment controls its own lifecycle and layout, and handles its input events, it cannot exist on its own: it must be hosted either by an activity or another fragment. This means that, normally, a fragment will be accessible by third-party applications (that is, exported) only if its hosting activity is itself exported.\n\n\n## Recommendation\nIn general, do not instantiate classes (including fragments) with user-provided names unless the name has been properly validated. Also, if an exported activity is extending the `PreferenceActivity` class, make sure that the `isValidFragment` method is overriden and only returns `true` when the provided `fragmentName` points to an intended fragment.\n\n\n## Example\nThe following example shows two cases: in the first one, untrusted data is used to instantiate and add a fragment to an activity, while in the second one, a fragment is safely added with a static name.\n\n\n```java\npublic class MyActivity extends FragmentActivity {\n\n    @Override\n    protected void onCreate(Bundle savedInstance) {\n        try {\n            super.onCreate(savedInstance);\n            // BAD: Fragment instantiated from user input without validation\n            {\n                String fName = getIntent().getStringExtra(\"fragmentName\");\n                getFragmentManager().beginTransaction().replace(com.android.internal.R.id.prefs,\n                        Fragment.instantiate(this, fName, null)).commit();\n            }\n            // GOOD: Fragment instantiated statically\n            {\n                getFragmentManager().beginTransaction()\n                        .replace(com.android.internal.R.id.prefs, new MyFragment()).commit();\n            }\n        } catch (Exception e) {\n        }\n    }\n\n}\n\n```\nThe next example shows two activities that extend `PreferenceActivity`. The first activity overrides `isValidFragment`, but it wrongly returns `true` unconditionally. The second activity correctly overrides `isValidFragment` so that it only returns `true` when `fragmentName` is a trusted fragment name.\n\n\n```java\nclass UnsafeActivity extends PreferenceActivity {\n\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // BAD: any Fragment name can be provided.\n        return true;\n    }\n}\n\n\nclass SafeActivity extends PreferenceActivity {\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // Good: only trusted Fragment names are allowed.\n        return SafeFragment1.class.getName().equals(fragmentName)\n                || SafeFragment2.class.getName().equals(fragmentName)\n                || SafeFragment3.class.getName().equals(fragmentName);\n    }\n\n}\n\n\n```\n\n## References\n* Google Help: [How to fix Fragment Injection vulnerability](https://support.google.com/faqs/answer/7188427?hl=en).\n* IBM Security Systems: [Android collapses into Fragments](https://securityintelligence.com/wp-content/uploads/2013/12/android-collapses-into-fragments.pdf).\n* Android Developers: [Fragments](https://developer.android.com/guide/fragments)\n* Common Weakness Enumeration: [CWE-470](https://cwe.mitre.org/data/definitions/470.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-470"
+                                    ],
+                                    "description": "Instantiating an Android fragment from a user-provided value\n              may allow a malicious application to bypass access controls,  exposing the application to unintended effects.",
+                                    "id": "java/android/fragment-injection",
+                                    "kind": "path-problem",
+                                    "name": "Android fragment injection",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/android/fragment-injection-preference-activity",
+                                "name": "java/android/fragment-injection-preference-activity",
+                                "shortDescription": {
+                                    "text": "Android fragment injection in PreferenceActivity"
+                                },
+                                "fullDescription": {
+                                    "text": "An insecure implementation of the 'isValidFragment' method of the 'PreferenceActivity' class may allow a malicious application to bypass access controls, exposing the application to unintended effects."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Android fragment injection in PreferenceActivity\nWhen fragments are instantiated with externally provided names, this exposes any exported activity that dynamically creates and hosts the fragment to fragment injection. A malicious application could provide the name of an arbitrary fragment, even one not designed to be externally accessible, and inject it into the activity. This can bypass access controls and expose the application to unintended effects.\n\nFragments are reusable parts of an Android application's user interface. Even though a fragment controls its own lifecycle and layout, and handles its input events, it cannot exist on its own: it must be hosted either by an activity or another fragment. This means that, normally, a fragment will be accessible by third-party applications (that is, exported) only if its hosting activity is itself exported.\n\n\n## Recommendation\nIn general, do not instantiate classes (including fragments) with user-provided names unless the name has been properly validated. Also, if an exported activity is extending the `PreferenceActivity` class, make sure that the `isValidFragment` method is overriden and only returns `true` when the provided `fragmentName` points to an intended fragment.\n\n\n## Example\nThe following example shows two cases: in the first one, untrusted data is used to instantiate and add a fragment to an activity, while in the second one, a fragment is safely added with a static name.\n\n\n```java\npublic class MyActivity extends FragmentActivity {\n\n    @Override\n    protected void onCreate(Bundle savedInstance) {\n        try {\n            super.onCreate(savedInstance);\n            // BAD: Fragment instantiated from user input without validation\n            {\n                String fName = getIntent().getStringExtra(\"fragmentName\");\n                getFragmentManager().beginTransaction().replace(com.android.internal.R.id.prefs,\n                        Fragment.instantiate(this, fName, null)).commit();\n            }\n            // GOOD: Fragment instantiated statically\n            {\n                getFragmentManager().beginTransaction()\n                        .replace(com.android.internal.R.id.prefs, new MyFragment()).commit();\n            }\n        } catch (Exception e) {\n        }\n    }\n\n}\n\n```\nThe next example shows two activities that extend `PreferenceActivity`. The first activity overrides `isValidFragment`, but it wrongly returns `true` unconditionally. The second activity correctly overrides `isValidFragment` so that it only returns `true` when `fragmentName` is a trusted fragment name.\n\n\n```java\nclass UnsafeActivity extends PreferenceActivity {\n\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // BAD: any Fragment name can be provided.\n        return true;\n    }\n}\n\n\nclass SafeActivity extends PreferenceActivity {\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // Good: only trusted Fragment names are allowed.\n        return SafeFragment1.class.getName().equals(fragmentName)\n                || SafeFragment2.class.getName().equals(fragmentName)\n                || SafeFragment3.class.getName().equals(fragmentName);\n    }\n\n}\n\n\n```\n\n## References\n* Google Help: [How to fix Fragment Injection vulnerability](https://support.google.com/faqs/answer/7188427?hl=en).\n* IBM Security Systems: [Android collapses into Fragments](https://securityintelligence.com/wp-content/uploads/2013/12/android-collapses-into-fragments.pdf).\n* Android Developers: [Fragments](https://developer.android.com/guide/fragments)\n* Common Weakness Enumeration: [CWE-470](https://cwe.mitre.org/data/definitions/470.html).\n",
+                                    "markdown": "# Android fragment injection in PreferenceActivity\nWhen fragments are instantiated with externally provided names, this exposes any exported activity that dynamically creates and hosts the fragment to fragment injection. A malicious application could provide the name of an arbitrary fragment, even one not designed to be externally accessible, and inject it into the activity. This can bypass access controls and expose the application to unintended effects.\n\nFragments are reusable parts of an Android application's user interface. Even though a fragment controls its own lifecycle and layout, and handles its input events, it cannot exist on its own: it must be hosted either by an activity or another fragment. This means that, normally, a fragment will be accessible by third-party applications (that is, exported) only if its hosting activity is itself exported.\n\n\n## Recommendation\nIn general, do not instantiate classes (including fragments) with user-provided names unless the name has been properly validated. Also, if an exported activity is extending the `PreferenceActivity` class, make sure that the `isValidFragment` method is overriden and only returns `true` when the provided `fragmentName` points to an intended fragment.\n\n\n## Example\nThe following example shows two cases: in the first one, untrusted data is used to instantiate and add a fragment to an activity, while in the second one, a fragment is safely added with a static name.\n\n\n```java\npublic class MyActivity extends FragmentActivity {\n\n    @Override\n    protected void onCreate(Bundle savedInstance) {\n        try {\n            super.onCreate(savedInstance);\n            // BAD: Fragment instantiated from user input without validation\n            {\n                String fName = getIntent().getStringExtra(\"fragmentName\");\n                getFragmentManager().beginTransaction().replace(com.android.internal.R.id.prefs,\n                        Fragment.instantiate(this, fName, null)).commit();\n            }\n            // GOOD: Fragment instantiated statically\n            {\n                getFragmentManager().beginTransaction()\n                        .replace(com.android.internal.R.id.prefs, new MyFragment()).commit();\n            }\n        } catch (Exception e) {\n        }\n    }\n\n}\n\n```\nThe next example shows two activities that extend `PreferenceActivity`. The first activity overrides `isValidFragment`, but it wrongly returns `true` unconditionally. The second activity correctly overrides `isValidFragment` so that it only returns `true` when `fragmentName` is a trusted fragment name.\n\n\n```java\nclass UnsafeActivity extends PreferenceActivity {\n\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // BAD: any Fragment name can be provided.\n        return true;\n    }\n}\n\n\nclass SafeActivity extends PreferenceActivity {\n    @Override\n    protected boolean isValidFragment(String fragmentName) {\n        // Good: only trusted Fragment names are allowed.\n        return SafeFragment1.class.getName().equals(fragmentName)\n                || SafeFragment2.class.getName().equals(fragmentName)\n                || SafeFragment3.class.getName().equals(fragmentName);\n    }\n\n}\n\n\n```\n\n## References\n* Google Help: [How to fix Fragment Injection vulnerability](https://support.google.com/faqs/answer/7188427?hl=en).\n* IBM Security Systems: [Android collapses into Fragments](https://securityintelligence.com/wp-content/uploads/2013/12/android-collapses-into-fragments.pdf).\n* Android Developers: [Fragments](https://developer.android.com/guide/fragments)\n* Common Weakness Enumeration: [CWE-470](https://cwe.mitre.org/data/definitions/470.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-470"
+                                    ],
+                                    "description": "An insecure implementation of the 'isValidFragment' method\n              of the 'PreferenceActivity' class may allow a malicious application to bypass access controls,\n              exposing the application to unintended effects.",
+                                    "id": "java/android/fragment-injection-preference-activity",
+                                    "kind": "problem",
+                                    "name": "Android fragment injection in PreferenceActivity",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/command-line-injection",
+                                "name": "java/command-line-injection",
+                                "shortDescription": {
+                                    "text": "Uncontrolled command line"
+                                },
+                                "fullDescription": {
+                                    "text": "Using externally controlled strings in a command line is vulnerable to malicious changes in the strings."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Uncontrolled command line\nCode that passes user input directly to `Runtime.exec`, or some other library routine that executes a command, allows the user to execute malicious code.\n\n\n## Recommendation\nIf possible, use hard-coded string literals to specify the command to run or library to load. Instead of passing the user input directly to the process or library function, examine the user input and then choose among hard-coded string literals.\n\nIf the applicable libraries or commands cannot be determined at compile time, then add code to verify that the user input string is safe before using it.\n\n\n## Example\nThe following example shows code that takes a shell script that can be changed maliciously by a user, and passes it straight to `Runtime.exec` without examining it first.\n\n\n```java\nclass Test {\n    public static void main(String[] args) {\n        String script = System.getenv(\"SCRIPTNAME\");\n        if (script != null) {\n            // BAD: The script to be executed is controlled by the user.\n            Runtime.getRuntime().exec(script);\n        }\n    }\n}\n```\n\n## References\n* OWASP: [Command Injection](https://www.owasp.org/index.php/Command_Injection).\n* SEI CERT Oracle Coding Standard for Java: [IDS07-J. Sanitize untrusted data passed to the Runtime.exec() method](https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec()+method).\n* Common Weakness Enumeration: [CWE-78](https://cwe.mitre.org/data/definitions/78.html).\n* Common Weakness Enumeration: [CWE-88](https://cwe.mitre.org/data/definitions/88.html).\n",
+                                    "markdown": "# Uncontrolled command line\nCode that passes user input directly to `Runtime.exec`, or some other library routine that executes a command, allows the user to execute malicious code.\n\n\n## Recommendation\nIf possible, use hard-coded string literals to specify the command to run or library to load. Instead of passing the user input directly to the process or library function, examine the user input and then choose among hard-coded string literals.\n\nIf the applicable libraries or commands cannot be determined at compile time, then add code to verify that the user input string is safe before using it.\n\n\n## Example\nThe following example shows code that takes a shell script that can be changed maliciously by a user, and passes it straight to `Runtime.exec` without examining it first.\n\n\n```java\nclass Test {\n    public static void main(String[] args) {\n        String script = System.getenv(\"SCRIPTNAME\");\n        if (script != null) {\n            // BAD: The script to be executed is controlled by the user.\n            Runtime.getRuntime().exec(script);\n        }\n    }\n}\n```\n\n## References\n* OWASP: [Command Injection](https://www.owasp.org/index.php/Command_Injection).\n* SEI CERT Oracle Coding Standard for Java: [IDS07-J. Sanitize untrusted data passed to the Runtime.exec() method](https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec()+method).\n* Common Weakness Enumeration: [CWE-78](https://cwe.mitre.org/data/definitions/78.html).\n* Common Weakness Enumeration: [CWE-88](https://cwe.mitre.org/data/definitions/88.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-078",
+                                        "external/cwe/cwe-088"
+                                    ],
+                                    "description": "Using externally controlled strings in a command line is vulnerable to malicious\n              changes in the strings.",
+                                    "id": "java/command-line-injection",
+                                    "kind": "path-problem",
+                                    "name": "Uncontrolled command line",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/concatenated-command-line",
+                                "name": "java/concatenated-command-line",
+                                "shortDescription": {
+                                    "text": "Building a command line with string concatenation"
+                                },
+                                "fullDescription": {
+                                    "text": "Using concatenated strings in a command line is vulnerable to malicious insertion of special characters in the strings."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Building a command line with string concatenation\nCode that builds a command line by concatenating strings that have been entered by a user allows the user to execute malicious code.\n\n\n## Recommendation\nExecute external commands using an array of strings rather than a single string. By using an array, many possible vulnerabilities in the formatting of the string are avoided.\n\n\n## Example\nIn the following example, `latlonCoords` contains a string that has been entered by a user but not validated by the program. This allows the user to, for example, append an ampersand (&amp;) followed by the command for a malicious program to the end of the string. The ampersand instructs Windows to execute another program. In the block marked 'BAD', `latlonCoords` is passed to `exec` as part of a concatenated string, which allows more than one command to be executed. However, in the block marked 'GOOD', `latlonCoords` is passed as part of an array, which means that `exec` treats it only as an argument.\n\n\n```java\nclass Test {\n    public static void main(String[] args) {\n        // BAD: user input might include special characters such as ampersands\n        {\n            String latlonCoords = args[1];\n            Runtime rt = Runtime.getRuntime();\n            Process exec = rt.exec(\"cmd.exe /C latlon2utm.exe \" + latlonCoords);\n        }\n\n        // GOOD: use an array of arguments instead of executing a string\n        {\n            String latlonCoords = args[1];\n            Runtime rt = Runtime.getRuntime();\n            Process exec = rt.exec(new String[] {\n                    \"c:\\\\path\\to\\latlon2utm.exe\",\n                    latlonCoords });\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Command Injection](https://www.owasp.org/index.php/Command_Injection).\n* SEI CERT Oracle Coding Standard for Java: [IDS07-J. Sanitize untrusted data passed to the Runtime.exec() method](https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec()+method).\n* Common Weakness Enumeration: [CWE-78](https://cwe.mitre.org/data/definitions/78.html).\n* Common Weakness Enumeration: [CWE-88](https://cwe.mitre.org/data/definitions/88.html).\n",
+                                    "markdown": "# Building a command line with string concatenation\nCode that builds a command line by concatenating strings that have been entered by a user allows the user to execute malicious code.\n\n\n## Recommendation\nExecute external commands using an array of strings rather than a single string. By using an array, many possible vulnerabilities in the formatting of the string are avoided.\n\n\n## Example\nIn the following example, `latlonCoords` contains a string that has been entered by a user but not validated by the program. This allows the user to, for example, append an ampersand (&amp;) followed by the command for a malicious program to the end of the string. The ampersand instructs Windows to execute another program. In the block marked 'BAD', `latlonCoords` is passed to `exec` as part of a concatenated string, which allows more than one command to be executed. However, in the block marked 'GOOD', `latlonCoords` is passed as part of an array, which means that `exec` treats it only as an argument.\n\n\n```java\nclass Test {\n    public static void main(String[] args) {\n        // BAD: user input might include special characters such as ampersands\n        {\n            String latlonCoords = args[1];\n            Runtime rt = Runtime.getRuntime();\n            Process exec = rt.exec(\"cmd.exe /C latlon2utm.exe \" + latlonCoords);\n        }\n\n        // GOOD: use an array of arguments instead of executing a string\n        {\n            String latlonCoords = args[1];\n            Runtime rt = Runtime.getRuntime();\n            Process exec = rt.exec(new String[] {\n                    \"c:\\\\path\\to\\latlon2utm.exe\",\n                    latlonCoords });\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Command Injection](https://www.owasp.org/index.php/Command_Injection).\n* SEI CERT Oracle Coding Standard for Java: [IDS07-J. Sanitize untrusted data passed to the Runtime.exec() method](https://wiki.sei.cmu.edu/confluence/display/java/IDS07-J.+Sanitize+untrusted+data+passed+to+the+Runtime.exec()+method).\n* Common Weakness Enumeration: [CWE-78](https://cwe.mitre.org/data/definitions/78.html).\n* Common Weakness Enumeration: [CWE-88](https://cwe.mitre.org/data/definitions/88.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-078",
+                                        "external/cwe/cwe-088"
+                                    ],
+                                    "description": "Using concatenated strings in a command line is vulnerable to malicious\n              insertion of special characters in the strings.",
+                                    "id": "java/concatenated-command-line",
+                                    "kind": "problem",
+                                    "name": "Building a command line with string concatenation",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/rsa-without-oaep",
+                                "name": "java/rsa-without-oaep",
+                                "shortDescription": {
+                                    "text": "Use of RSA algorithm without OAEP"
+                                },
+                                "fullDescription": {
+                                    "text": "Using RSA encryption without OAEP padding can result in a padding oracle attack, leading to a weaker encryption."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Use of RSA algorithm without OAEP\nCryptographic algorithms often use padding schemes to make the plaintext less predictable. The OAEP (Optimal Asymmetric Encryption Padding) scheme should be used with RSA encryption. Using an outdated padding scheme such as PKCS1, or no padding at all, can weaken the encryption by making it vulnerable to a padding oracle attack.\n\n\n## Recommendation\nUse the OAEP scheme when using RSA encryption.\n\n\n## Example\nIn the following example, the BAD case shows no padding being used, whereas the GOOD case shows an OAEP scheme being used.\n\n\n```java\n// BAD: No padding scheme is used\nCipher rsa = Cipher.getInstance(\"RSA/ECB/NoPadding\");\n...\n\n//GOOD: OAEP padding is used\nCipher rsa = Cipher.getInstance(\"RSA/ECB/OAEPWithSHA-1AndMGF1Padding\");\n...\n```\n\n## References\n* [Mobile Security Testing Guide](https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#padding-oracle-attacks-due-to-weaker-padding-or-block-operation-implementations).\n* [The Padding Oracle Attack](https://robertheaton.com/2013/07/29/padding-oracle-attack/).\n* Common Weakness Enumeration: [CWE-780](https://cwe.mitre.org/data/definitions/780.html).\n",
+                                    "markdown": "# Use of RSA algorithm without OAEP\nCryptographic algorithms often use padding schemes to make the plaintext less predictable. The OAEP (Optimal Asymmetric Encryption Padding) scheme should be used with RSA encryption. Using an outdated padding scheme such as PKCS1, or no padding at all, can weaken the encryption by making it vulnerable to a padding oracle attack.\n\n\n## Recommendation\nUse the OAEP scheme when using RSA encryption.\n\n\n## Example\nIn the following example, the BAD case shows no padding being used, whereas the GOOD case shows an OAEP scheme being used.\n\n\n```java\n// BAD: No padding scheme is used\nCipher rsa = Cipher.getInstance(\"RSA/ECB/NoPadding\");\n...\n\n//GOOD: OAEP padding is used\nCipher rsa = Cipher.getInstance(\"RSA/ECB/OAEPWithSHA-1AndMGF1Padding\");\n...\n```\n\n## References\n* [Mobile Security Testing Guide](https://github.com/MobSF/owasp-mstg/blob/master/Document/0x04g-Testing-Cryptography.md#padding-oracle-attacks-due-to-weaker-padding-or-block-operation-implementations).\n* [The Padding Oracle Attack](https://robertheaton.com/2013/07/29/padding-oracle-attack/).\n* Common Weakness Enumeration: [CWE-780](https://cwe.mitre.org/data/definitions/780.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-780"
+                                    ],
+                                    "description": "Using RSA encryption without OAEP padding can result in a padding oracle attack, leading to a weaker encryption.",
+                                    "id": "java/rsa-without-oaep",
+                                    "kind": "path-problem",
+                                    "name": "Use of RSA algorithm without OAEP",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/jndi-injection",
+                                "name": "java/jndi-injection",
+                                "shortDescription": {
+                                    "text": "JNDI lookup with user-controlled name"
+                                },
+                                "fullDescription": {
+                                    "text": "Performing a JNDI lookup with a user-controlled name can lead to the download of an untrusted object and to execution of arbitrary code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# JNDI lookup with user-controlled name\nThe Java Naming and Directory Interface (JNDI) is a Java API for a directory service that allows Java software clients to discover and look up data and resources (in the form of Java objects) via a name. If the name being used to look up the data is controlled by the user, it can point to a malicious server, which can return an arbitrary object. In the worst case, this can allow remote code execution.\n\n\n## Recommendation\nThe general recommendation is to avoid passing untrusted data to the `InitialContext.lookup ` method. If the name being used to look up the object must be provided by the user, make sure that it's not in the form of an absolute URL or that it's the URL pointing to a trused server.\n\n\n## Example\nIn the following examples, the code accepts a name from the user, which it uses to look up an object.\n\nIn the first example, the user provided name is used to look up an object.\n\nThe second example validates the name before using it to look up an object.\n\n\n```java\nimport javax.naming.Context;\nimport javax.naming.InitialContext;\n\npublic void jndiLookup(HttpServletRequest request) throws NamingException {\n  String name = request.getParameter(\"name\");\n\n  Hashtable<String, String> env = new Hashtable<String, String>();\n  env.put(Context.INITIAL_CONTEXT_FACTORY, \"com.sun.jndi.rmi.registry.RegistryContextFactory\");\n  env.put(Context.PROVIDER_URL, \"rmi://trusted-server:1099\");\n  InitialContext ctx = new InitialContext(env);\n\n  // BAD: User input used in lookup\n  ctx.lookup(name);\n\n  // GOOD: The name is validated before being used in lookup\n  if (isValid(name)) {\n    ctx.lookup(name);\n  } else {\n    // Reject the request\n  }\n}\n```\n\n## References\n* Oracle: [Java Naming and Directory Interface (JNDI)](https://docs.oracle.com/javase/8/docs/technotes/guides/jndi/).\n* Black Hat materials: [A Journey from JNDI/LDAP Manipulation to Remote Code Execution Dream Land](https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE-wp.pdf).\n* Veracode: [Exploiting JNDI Injections in Java](https://www.veracode.com/blog/research/exploiting-jndi-injections-java).\n* Common Weakness Enumeration: [CWE-74](https://cwe.mitre.org/data/definitions/74.html).\n",
+                                    "markdown": "# JNDI lookup with user-controlled name\nThe Java Naming and Directory Interface (JNDI) is a Java API for a directory service that allows Java software clients to discover and look up data and resources (in the form of Java objects) via a name. If the name being used to look up the data is controlled by the user, it can point to a malicious server, which can return an arbitrary object. In the worst case, this can allow remote code execution.\n\n\n## Recommendation\nThe general recommendation is to avoid passing untrusted data to the `InitialContext.lookup ` method. If the name being used to look up the object must be provided by the user, make sure that it's not in the form of an absolute URL or that it's the URL pointing to a trused server.\n\n\n## Example\nIn the following examples, the code accepts a name from the user, which it uses to look up an object.\n\nIn the first example, the user provided name is used to look up an object.\n\nThe second example validates the name before using it to look up an object.\n\n\n```java\nimport javax.naming.Context;\nimport javax.naming.InitialContext;\n\npublic void jndiLookup(HttpServletRequest request) throws NamingException {\n  String name = request.getParameter(\"name\");\n\n  Hashtable<String, String> env = new Hashtable<String, String>();\n  env.put(Context.INITIAL_CONTEXT_FACTORY, \"com.sun.jndi.rmi.registry.RegistryContextFactory\");\n  env.put(Context.PROVIDER_URL, \"rmi://trusted-server:1099\");\n  InitialContext ctx = new InitialContext(env);\n\n  // BAD: User input used in lookup\n  ctx.lookup(name);\n\n  // GOOD: The name is validated before being used in lookup\n  if (isValid(name)) {\n    ctx.lookup(name);\n  } else {\n    // Reject the request\n  }\n}\n```\n\n## References\n* Oracle: [Java Naming and Directory Interface (JNDI)](https://docs.oracle.com/javase/8/docs/technotes/guides/jndi/).\n* Black Hat materials: [A Journey from JNDI/LDAP Manipulation to Remote Code Execution Dream Land](https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE-wp.pdf).\n* Veracode: [Exploiting JNDI Injections in Java](https://www.veracode.com/blog/research/exploiting-jndi-injections-java).\n* Common Weakness Enumeration: [CWE-74](https://cwe.mitre.org/data/definitions/74.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-074"
+                                    ],
+                                    "description": "Performing a JNDI lookup with a user-controlled name can lead to the download of an untrusted\n              object and to execution of arbitrary code.",
+                                    "id": "java/jndi-injection",
+                                    "kind": "path-problem",
+                                    "name": "JNDI lookup with user-controlled name",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/xslt-injection",
+                                "name": "java/xslt-injection",
+                                "shortDescription": {
+                                    "text": "XSLT transformation with user-controlled stylesheet"
+                                },
+                                "fullDescription": {
+                                    "text": "Performing an XSLT transformation with user-controlled stylesheets can lead to information disclosure or execution of arbitrary code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# XSLT transformation with user-controlled stylesheet\nXSLT (Extensible Stylesheet Language Transformations) is a language for transforming XML documents into other XML documents or other formats. Processing unvalidated XSLT stylesheets can allow attackers to read arbitrary files from the filesystem or to execute arbitrary code.\n\n\n## Recommendation\nThe general recommendation is to not process untrusted XSLT stylesheets. If user-provided stylesheets must be processed, enable the secure processing mode.\n\n\n## Example\nIn the following examples, the code accepts an XSLT stylesheet from the user and processes it.\n\nIn the first example, the user-provided XSLT stylesheet is parsed and processed.\n\nIn the second example, secure processing mode is enabled.\n\n\n```java\nimport javax.xml.XMLConstants;\nimport javax.xml.transform.TransformerFactory;\nimport javax.xml.transform.stream.StreamResult;\nimport javax.xml.transform.stream.StreamSource;\n\npublic void transform(Socket socket, String inputXml) throws Exception {\n  StreamSource xslt = new StreamSource(socket.getInputStream());\n  StreamSource xml = new StreamSource(new StringReader(inputXml));\n  StringWriter result = new StringWriter();\n  TransformerFactory factory = TransformerFactory.newInstance();\n\n  // BAD: User provided XSLT stylesheet is processed\n  factory.newTransformer(xslt).transform(xml, new StreamResult(result));\n\n  // GOOD: The secure processing mode is enabled\n  factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n  factory.newTransformer(xslt).transform(xml, new StreamResult(result));\n}  \n```\n\n## References\n* Wikipedia: [XSLT](https://en.wikipedia.org/wiki/XSLT).\n* The Java Tutorials: [Transforming XML Data with XSLT](https://docs.oracle.com/javase/tutorial/jaxp/xslt/transformingXML.html).\n* [XSLT Injection Basics](https://blog.hunniccyber.com/ektron-cms-remote-code-execution-xslt-transform-injection-java/).\n* Common Weakness Enumeration: [CWE-74](https://cwe.mitre.org/data/definitions/74.html).\n",
+                                    "markdown": "# XSLT transformation with user-controlled stylesheet\nXSLT (Extensible Stylesheet Language Transformations) is a language for transforming XML documents into other XML documents or other formats. Processing unvalidated XSLT stylesheets can allow attackers to read arbitrary files from the filesystem or to execute arbitrary code.\n\n\n## Recommendation\nThe general recommendation is to not process untrusted XSLT stylesheets. If user-provided stylesheets must be processed, enable the secure processing mode.\n\n\n## Example\nIn the following examples, the code accepts an XSLT stylesheet from the user and processes it.\n\nIn the first example, the user-provided XSLT stylesheet is parsed and processed.\n\nIn the second example, secure processing mode is enabled.\n\n\n```java\nimport javax.xml.XMLConstants;\nimport javax.xml.transform.TransformerFactory;\nimport javax.xml.transform.stream.StreamResult;\nimport javax.xml.transform.stream.StreamSource;\n\npublic void transform(Socket socket, String inputXml) throws Exception {\n  StreamSource xslt = new StreamSource(socket.getInputStream());\n  StreamSource xml = new StreamSource(new StringReader(inputXml));\n  StringWriter result = new StringWriter();\n  TransformerFactory factory = TransformerFactory.newInstance();\n\n  // BAD: User provided XSLT stylesheet is processed\n  factory.newTransformer(xslt).transform(xml, new StreamResult(result));\n\n  // GOOD: The secure processing mode is enabled\n  factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);\n  factory.newTransformer(xslt).transform(xml, new StreamResult(result));\n}  \n```\n\n## References\n* Wikipedia: [XSLT](https://en.wikipedia.org/wiki/XSLT).\n* The Java Tutorials: [Transforming XML Data with XSLT](https://docs.oracle.com/javase/tutorial/jaxp/xslt/transformingXML.html).\n* [XSLT Injection Basics](https://blog.hunniccyber.com/ektron-cms-remote-code-execution-xslt-transform-injection-java/).\n* Common Weakness Enumeration: [CWE-74](https://cwe.mitre.org/data/definitions/74.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-074"
+                                    ],
+                                    "description": "Performing an XSLT transformation with user-controlled stylesheets can lead to\n              information disclosure or execution of arbitrary code.",
+                                    "id": "java/xslt-injection",
+                                    "kind": "path-problem",
+                                    "name": "XSLT transformation with user-controlled stylesheet",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/static-initialization-vector",
+                                "name": "java/static-initialization-vector",
+                                "shortDescription": {
+                                    "text": "Using a static initialization vector for encryption"
+                                },
+                                "fullDescription": {
+                                    "text": "An initialization vector (IV) used for ciphers of certain modes (such as CBC or GCM) should be unique and unpredictable, to maximize encryption and prevent dictionary attacks."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Using a static initialization vector for encryption\nWhen a cipher is used in certain modes such as CBC or GCM, it requires an initialization vector (IV). Under the same secret key, IVs should be unique and ideally unpredictable. If the same IV is used with the same secret key, then the same plaintext results in the same ciphertext. This can let an attacker learn if the same data pieces are transferred or stored, or help the attacker run a dictionary attack.\n\n\n## Recommendation\nUse a random IV generated by `SecureRandom`.\n\n\n## Example\nThe following example initializes a cipher with a static IV, which is unsafe:\n\n\n```java\nbyte[] iv = new byte[16]; // all zeroes\nGCMParameterSpec params = new GCMParameterSpec(128, iv);\nCipher cipher = Cipher.getInstance(\"AES/GCM/PKCS5PADDING\");\ncipher.init(Cipher.ENCRYPT_MODE, key, params);\n```\nThe next example initializes a cipher with a random IV:\n\n\n```java\nbyte[] iv = new byte[16];\nSecureRandom random = SecureRandom.getInstanceStrong();\nrandom.nextBytes(iv);\nGCMParameterSpec params = new GCMParameterSpec(128, iv);\nCipher cipher = Cipher.getInstance(\"AES/GCM/PKCS5PADDING\");\ncipher.init(Cipher.ENCRYPT_MODE, key, params);\n```\n\n## References\n* Wikipedia: [Initialization vector](https://en.wikipedia.org/wiki/Initialization_vector).\n* National Institute of Standards and Technology: [Recommendation for Block Cipher Modes of Operation](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf).\n* National Institute of Standards and Technology: [FIPS 140-2: Security Requirements for Cryptographic Modules](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf).\n* Common Weakness Enumeration: [CWE-329](https://cwe.mitre.org/data/definitions/329.html).\n* Common Weakness Enumeration: [CWE-1204](https://cwe.mitre.org/data/definitions/1204.html).\n",
+                                    "markdown": "# Using a static initialization vector for encryption\nWhen a cipher is used in certain modes such as CBC or GCM, it requires an initialization vector (IV). Under the same secret key, IVs should be unique and ideally unpredictable. If the same IV is used with the same secret key, then the same plaintext results in the same ciphertext. This can let an attacker learn if the same data pieces are transferred or stored, or help the attacker run a dictionary attack.\n\n\n## Recommendation\nUse a random IV generated by `SecureRandom`.\n\n\n## Example\nThe following example initializes a cipher with a static IV, which is unsafe:\n\n\n```java\nbyte[] iv = new byte[16]; // all zeroes\nGCMParameterSpec params = new GCMParameterSpec(128, iv);\nCipher cipher = Cipher.getInstance(\"AES/GCM/PKCS5PADDING\");\ncipher.init(Cipher.ENCRYPT_MODE, key, params);\n```\nThe next example initializes a cipher with a random IV:\n\n\n```java\nbyte[] iv = new byte[16];\nSecureRandom random = SecureRandom.getInstanceStrong();\nrandom.nextBytes(iv);\nGCMParameterSpec params = new GCMParameterSpec(128, iv);\nCipher cipher = Cipher.getInstance(\"AES/GCM/PKCS5PADDING\");\ncipher.init(Cipher.ENCRYPT_MODE, key, params);\n```\n\n## References\n* Wikipedia: [Initialization vector](https://en.wikipedia.org/wiki/Initialization_vector).\n* National Institute of Standards and Technology: [Recommendation for Block Cipher Modes of Operation](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf).\n* National Institute of Standards and Technology: [FIPS 140-2: Security Requirements for Cryptographic Modules](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf).\n* Common Weakness Enumeration: [CWE-329](https://cwe.mitre.org/data/definitions/329.html).\n* Common Weakness Enumeration: [CWE-1204](https://cwe.mitre.org/data/definitions/1204.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-329",
+                                        "external/cwe/cwe-1204"
+                                    ],
+                                    "description": "An initialization vector (IV) used for ciphers of certain modes (such as CBC or GCM) should be unique and unpredictable, to maximize encryption and prevent dictionary attacks.",
+                                    "id": "java/static-initialization-vector",
+                                    "kind": "path-problem",
+                                    "name": "Using a static initialization vector for encryption",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/xml/xpath-injection",
+                                "name": "java/xml/xpath-injection",
+                                "shortDescription": {
+                                    "text": "XPath injection"
+                                },
+                                "fullDescription": {
+                                    "text": "Building an XPath expression from user-controlled sources is vulnerable to insertion of malicious code by the user."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# XPath injection\nIf an XPath expression is built using string concatenation, and the components of the concatenation include user input, it makes it very easy for a user to create a malicious XPath expression.\n\n\n## Recommendation\nIf user input must be included in an XPath expression, either sanitize the data or pre-compile the query and use variable references to include the user input.\n\nXPath injection can also be prevented by using XQuery.\n\n\n## Example\nIn the first three examples, the code accepts a name and password specified by the user, and uses this unvalidated and unsanitized value in an XPath expression. This is vulnerable to the user providing special characters or string sequences that change the meaning of the XPath expression to search for different values.\n\nIn the fourth example, the code uses `setXPathVariableResolver` which prevents XPath injection.\n\nThe final two examples are for dom4j. They show an example of XPath injection and one method of preventing it.\n\n\n```java\nfinal String xmlStr = \"<users>\" + \n                        \"   <user name=\\\"aaa\\\" pass=\\\"pass1\\\"></user>\" + \n                        \"   <user name=\\\"bbb\\\" pass=\\\"pass2\\\"></user>\" + \n                        \"</users>\";\ntry {\n    DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();\n    domFactory.setNamespaceAware(true);\n    DocumentBuilder builder = domFactory.newDocumentBuilder();\n    //Document doc = builder.parse(\"user.xml\");\n    Document doc = builder.parse(new InputSource(new StringReader(xmlStr)));\n\n    XPathFactory factory = XPathFactory.newInstance();\n    XPath xpath = factory.newXPath();\n\n    // Injectable data\n    String user = request.getParameter(\"user\");\n    String pass = request.getParameter(\"pass\");\n    if (user != null && pass != null) {\n        boolean isExist = false;\n\n        // Bad expression\n        String expression1 = \"/users/user[@name='\" + user + \"' and @pass='\" + pass + \"']\";\n        isExist = (boolean)xpath.evaluate(expression1, doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n        // Bad expression\n        XPathExpression expression2 = xpath.compile(\"/users/user[@name='\" + user + \"' and @pass='\" + pass + \"']\");\n        isExist = (boolean)expression2.evaluate(doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n        // Bad expression\n        StringBuffer sb = new StringBuffer(\"/users/user[@name=\");\n        sb.append(user);\n        sb.append(\"' and @pass='\");\n        sb.append(pass);\n        sb.append(\"']\");\n        String query = sb.toString();\n        XPathExpression expression3 = xpath.compile(query);\n        isExist = (boolean)expression3.evaluate(doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n        // Good expression\n        String expression4 = \"/users/user[@name=$user and @pass=$pass]\";\n        xpath.setXPathVariableResolver(v -> {\n        switch (v.getLocalPart()) {\n            case \"user\":\n                return user;\n            case \"pass\":\n                return pass;\n            default:\n                throw new IllegalArgumentException();\n            }\n        });\n        isExist = (boolean)xpath.evaluate(expression4, doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n\n        // Bad Dom4j \n        org.dom4j.io.SAXReader reader = new org.dom4j.io.SAXReader();\n        org.dom4j.Document document = reader.read(new InputSource(new StringReader(xmlStr)));\n        isExist = document.selectSingleNode(\"/users/user[@name='\" + user + \"' and @pass='\" + pass + \"']\") != null;\n        // or document.selectNodes\n        System.out.println(isExist);\n\n        // Good Dom4j\n        org.jaxen.SimpleVariableContext svc = new org.jaxen.SimpleVariableContext();\n        svc.setVariableValue(\"user\", user);\n        svc.setVariableValue(\"pass\", pass);\n        String xpathString = \"/users/user[@name=$user and @pass=$pass]\";\n        org.dom4j.XPath safeXPath = document.createXPath(xpathString);\n        safeXPath.setVariableContext(svc);\n        isExist = safeXPath.selectSingleNode(document) != null;\n        System.out.println(isExist);\n    }\n} catch (ParserConfigurationException e) {\n\n} catch (SAXException e) {\n\n} catch (XPathExpressionException e) {\n\n} catch (org.dom4j.DocumentException e) {\n\n}\n```\n\n## References\n* OWASP: [Testing for XPath Injection](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection).\n* OWASP: [XPath Injection](https://owasp.org/www-community/attacks/XPATH_Injection).\n* Common Weakness Enumeration: [CWE-643](https://cwe.mitre.org/data/definitions/643.html).\n",
+                                    "markdown": "# XPath injection\nIf an XPath expression is built using string concatenation, and the components of the concatenation include user input, it makes it very easy for a user to create a malicious XPath expression.\n\n\n## Recommendation\nIf user input must be included in an XPath expression, either sanitize the data or pre-compile the query and use variable references to include the user input.\n\nXPath injection can also be prevented by using XQuery.\n\n\n## Example\nIn the first three examples, the code accepts a name and password specified by the user, and uses this unvalidated and unsanitized value in an XPath expression. This is vulnerable to the user providing special characters or string sequences that change the meaning of the XPath expression to search for different values.\n\nIn the fourth example, the code uses `setXPathVariableResolver` which prevents XPath injection.\n\nThe final two examples are for dom4j. They show an example of XPath injection and one method of preventing it.\n\n\n```java\nfinal String xmlStr = \"<users>\" + \n                        \"   <user name=\\\"aaa\\\" pass=\\\"pass1\\\"></user>\" + \n                        \"   <user name=\\\"bbb\\\" pass=\\\"pass2\\\"></user>\" + \n                        \"</users>\";\ntry {\n    DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();\n    domFactory.setNamespaceAware(true);\n    DocumentBuilder builder = domFactory.newDocumentBuilder();\n    //Document doc = builder.parse(\"user.xml\");\n    Document doc = builder.parse(new InputSource(new StringReader(xmlStr)));\n\n    XPathFactory factory = XPathFactory.newInstance();\n    XPath xpath = factory.newXPath();\n\n    // Injectable data\n    String user = request.getParameter(\"user\");\n    String pass = request.getParameter(\"pass\");\n    if (user != null && pass != null) {\n        boolean isExist = false;\n\n        // Bad expression\n        String expression1 = \"/users/user[@name='\" + user + \"' and @pass='\" + pass + \"']\";\n        isExist = (boolean)xpath.evaluate(expression1, doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n        // Bad expression\n        XPathExpression expression2 = xpath.compile(\"/users/user[@name='\" + user + \"' and @pass='\" + pass + \"']\");\n        isExist = (boolean)expression2.evaluate(doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n        // Bad expression\n        StringBuffer sb = new StringBuffer(\"/users/user[@name=\");\n        sb.append(user);\n        sb.append(\"' and @pass='\");\n        sb.append(pass);\n        sb.append(\"']\");\n        String query = sb.toString();\n        XPathExpression expression3 = xpath.compile(query);\n        isExist = (boolean)expression3.evaluate(doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n        // Good expression\n        String expression4 = \"/users/user[@name=$user and @pass=$pass]\";\n        xpath.setXPathVariableResolver(v -> {\n        switch (v.getLocalPart()) {\n            case \"user\":\n                return user;\n            case \"pass\":\n                return pass;\n            default:\n                throw new IllegalArgumentException();\n            }\n        });\n        isExist = (boolean)xpath.evaluate(expression4, doc, XPathConstants.BOOLEAN);\n        System.out.println(isExist);\n\n\n        // Bad Dom4j \n        org.dom4j.io.SAXReader reader = new org.dom4j.io.SAXReader();\n        org.dom4j.Document document = reader.read(new InputSource(new StringReader(xmlStr)));\n        isExist = document.selectSingleNode(\"/users/user[@name='\" + user + \"' and @pass='\" + pass + \"']\") != null;\n        // or document.selectNodes\n        System.out.println(isExist);\n\n        // Good Dom4j\n        org.jaxen.SimpleVariableContext svc = new org.jaxen.SimpleVariableContext();\n        svc.setVariableValue(\"user\", user);\n        svc.setVariableValue(\"pass\", pass);\n        String xpathString = \"/users/user[@name=$user and @pass=$pass]\";\n        org.dom4j.XPath safeXPath = document.createXPath(xpathString);\n        safeXPath.setVariableContext(svc);\n        isExist = safeXPath.selectSingleNode(document) != null;\n        System.out.println(isExist);\n    }\n} catch (ParserConfigurationException e) {\n\n} catch (SAXException e) {\n\n} catch (XPathExpressionException e) {\n\n} catch (org.dom4j.DocumentException e) {\n\n}\n```\n\n## References\n* OWASP: [Testing for XPath Injection](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection).\n* OWASP: [XPath Injection](https://owasp.org/www-community/attacks/XPATH_Injection).\n* Common Weakness Enumeration: [CWE-643](https://cwe.mitre.org/data/definitions/643.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-643"
+                                    ],
+                                    "description": "Building an XPath expression from user-controlled sources is vulnerable to insertion of\n              malicious code by the user.",
+                                    "id": "java/xml/xpath-injection",
+                                    "kind": "path-problem",
+                                    "name": "XPath injection",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/spring-disabled-csrf-protection",
+                                "name": "java/spring-disabled-csrf-protection",
+                                "shortDescription": {
+                                    "text": "Disabled Spring CSRF protection"
+                                },
+                                "fullDescription": {
+                                    "text": "Disabling CSRF protection makes the application vulnerable to a Cross-Site Request Forgery (CSRF) attack."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Disabled Spring CSRF protection\nWhen you set up a web server to receive a request from a client without any mechanism for verifying that it was intentionally sent, then it is vulnerable to attack. An attacker can trick a client into making an unintended request to the web server that will be treated as an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can result in exposure of data or unintended code execution.\n\n\n## Recommendation\nWhen you use Spring, Cross-Site Request Forgery (CSRF) protection is enabled by default. Spring's recommendation is to use CSRF protection for any request that could be processed by a browser client by normal users.\n\n\n## Example\nThe following example shows the Spring Java configuration with CSRF protection disabled. This type of configuration should only be used if you are creating a service that is used only by non-browser clients.\n\n\n```java\nimport org.springframework.context.annotation.Configuration;\nimport org.springframework.security.config.annotation.web.builders.HttpSecurity;\nimport org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;\nimport org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;\n\n@EnableWebSecurity\n@Configuration\npublic class WebSecurityConfig extends WebSecurityConfigurerAdapter {\n  @Override\n  protected void configure(HttpSecurity http) throws Exception {\n    http\n      .csrf(csrf ->\n        // BAD - CSRF protection shouldn't be disabled\n        csrf.disable() \n      );\n  }\n}\n\n```\n\n## References\n* OWASP: [Cross-Site Request Forgery (CSRF)](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)).\n* Spring Security Reference: [ Cross Site Request Forgery (CSRF) for Servlet Environments ](https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf).\n* Common Weakness Enumeration: [CWE-352](https://cwe.mitre.org/data/definitions/352.html).\n",
+                                    "markdown": "# Disabled Spring CSRF protection\nWhen you set up a web server to receive a request from a client without any mechanism for verifying that it was intentionally sent, then it is vulnerable to attack. An attacker can trick a client into making an unintended request to the web server that will be treated as an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can result in exposure of data or unintended code execution.\n\n\n## Recommendation\nWhen you use Spring, Cross-Site Request Forgery (CSRF) protection is enabled by default. Spring's recommendation is to use CSRF protection for any request that could be processed by a browser client by normal users.\n\n\n## Example\nThe following example shows the Spring Java configuration with CSRF protection disabled. This type of configuration should only be used if you are creating a service that is used only by non-browser clients.\n\n\n```java\nimport org.springframework.context.annotation.Configuration;\nimport org.springframework.security.config.annotation.web.builders.HttpSecurity;\nimport org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;\nimport org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;\n\n@EnableWebSecurity\n@Configuration\npublic class WebSecurityConfig extends WebSecurityConfigurerAdapter {\n  @Override\n  protected void configure(HttpSecurity http) throws Exception {\n    http\n      .csrf(csrf ->\n        // BAD - CSRF protection shouldn't be disabled\n        csrf.disable() \n      );\n  }\n}\n\n```\n\n## References\n* OWASP: [Cross-Site Request Forgery (CSRF)](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)).\n* Spring Security Reference: [ Cross Site Request Forgery (CSRF) for Servlet Environments ](https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf).\n* Common Weakness Enumeration: [CWE-352](https://cwe.mitre.org/data/definitions/352.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-352"
+                                    ],
+                                    "description": "Disabling CSRF protection makes the application vulnerable to\n              a Cross-Site Request Forgery (CSRF) attack.",
+                                    "id": "java/spring-disabled-csrf-protection",
+                                    "kind": "problem",
+                                    "name": "Disabled Spring CSRF protection",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "8.8"
+                                }
+                            },
+                            {
+                                "id": "java/xxe",
+                                "name": "java/xxe",
+                                "shortDescription": {
+                                    "text": "Resolving XML external entity in user-controlled data"
+                                },
+                                "fullDescription": {
+                                    "text": "Parsing user-controlled XML documents and allowing expansion of external entity references may lead to disclosure of confidential data or denial of service."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Resolving XML external entity in user-controlled data\nParsing untrusted XML files with a weakly configured XML parser may lead to an XML External Entity (XXE) attack. This type of attack uses external entity references to access arbitrary files on a system, carry out denial of service, or server side request forgery. Even when the result of parsing is not returned to the user, out-of-band data retrieval techniques may allow attackers to steal sensitive data. Denial of services can also be carried out in this situation.\n\nThere are many XML parsers for Java, and most of them are vulnerable to XXE because their default settings enable parsing of external entities. This query currently identifies vulnerable XML parsing from the following parsers: `javax.xml.parsers.DocumentBuilder`, `javax.xml.stream.XMLStreamReader`, `org.jdom.input.SAXBuilder`/`org.jdom2.input.SAXBuilder`, `javax.xml.parsers.SAXParser`,`org.dom4j.io.SAXReader`, `org.xml.sax.XMLReader`, `javax.xml.transform.sax.SAXSource`, `javax.xml.transform.TransformerFactory`, `javax.xml.transform.sax.SAXTransformerFactory`, `javax.xml.validation.SchemaFactory`, `javax.xml.bind.Unmarshaller` and `javax.xml.xpath.XPathExpression`.\n\n\n## Recommendation\nThe best way to prevent XXE attacks is to disable the parsing of any Document Type Declarations (DTDs) in untrusted data. If this is not possible you should disable the parsing of external general entities and external parameter entities. This improves security but the code will still be at risk of denial of service and server side request forgery attacks. Protection against denial of service attacks may also be implemented by setting entity expansion limits, which is done by default in recent JDK and JRE implementations. Because there are many different ways to disable external entity retrieval with varying support between different providers, in this query we choose to specifically check for the [OWASP recommended way](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java) to disable external entity retrieval for a particular parser. There may be other ways of making a particular parser safe which deviate from these guidelines, in which case this query will continue to flag the parser as potentially dangerous.\n\n\n## Example\nThe following example calls `parse` on a `DocumentBuilder` that is not safely configured on untrusted data, and is therefore inherently unsafe.\n\n\n```java\npublic void parse(Socket sock) throws Exception {\n  DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n  DocumentBuilder builder = factory.newDocumentBuilder();\n  builder.parse(sock.getInputStream()); //unsafe\n}\n\n```\nIn this example, the `DocumentBuilder` is created with DTD disabled, securing it against XXE attack.\n\n\n```java\npublic void disableDTDParse(Socket sock) throws Exception {\n  DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n  factory.setFeature(\"http://apache.org/xml/features/disallow-doctype-decl\", true);\n  DocumentBuilder builder = factory.newDocumentBuilder();\n  builder.parse(sock.getInputStream()); //safe\n}\n\n```\n\n## References\n* OWASP vulnerability description: [XML External Entity (XXE) Processing](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing).\n* OWASP guidance on parsing xml files: [XXE Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java).\n* Paper by Timothy Morgen: [XML Schema, DTD, and Entity Attacks](https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/)\n* Out-of-band data retrieval: Timur Yunusov &amp; Alexey Osipov, Black hat EU 2013: [XML Out-Of-Band Data Retrieval](https://www.slideshare.net/qqlan/bh-ready-v4).\n* Denial of service attack (Billion laughs): [Billion Laughs.](https://en.wikipedia.org/wiki/Billion_laughs)\n* The Java Tutorials: [Processing Limit Definitions.](https://docs.oracle.com/javase/tutorial/jaxp/limits/limits.html)\n* Common Weakness Enumeration: [CWE-611](https://cwe.mitre.org/data/definitions/611.html).\n* Common Weakness Enumeration: [CWE-776](https://cwe.mitre.org/data/definitions/776.html).\n* Common Weakness Enumeration: [CWE-827](https://cwe.mitre.org/data/definitions/827.html).\n",
+                                    "markdown": "# Resolving XML external entity in user-controlled data\nParsing untrusted XML files with a weakly configured XML parser may lead to an XML External Entity (XXE) attack. This type of attack uses external entity references to access arbitrary files on a system, carry out denial of service, or server side request forgery. Even when the result of parsing is not returned to the user, out-of-band data retrieval techniques may allow attackers to steal sensitive data. Denial of services can also be carried out in this situation.\n\nThere are many XML parsers for Java, and most of them are vulnerable to XXE because their default settings enable parsing of external entities. This query currently identifies vulnerable XML parsing from the following parsers: `javax.xml.parsers.DocumentBuilder`, `javax.xml.stream.XMLStreamReader`, `org.jdom.input.SAXBuilder`/`org.jdom2.input.SAXBuilder`, `javax.xml.parsers.SAXParser`,`org.dom4j.io.SAXReader`, `org.xml.sax.XMLReader`, `javax.xml.transform.sax.SAXSource`, `javax.xml.transform.TransformerFactory`, `javax.xml.transform.sax.SAXTransformerFactory`, `javax.xml.validation.SchemaFactory`, `javax.xml.bind.Unmarshaller` and `javax.xml.xpath.XPathExpression`.\n\n\n## Recommendation\nThe best way to prevent XXE attacks is to disable the parsing of any Document Type Declarations (DTDs) in untrusted data. If this is not possible you should disable the parsing of external general entities and external parameter entities. This improves security but the code will still be at risk of denial of service and server side request forgery attacks. Protection against denial of service attacks may also be implemented by setting entity expansion limits, which is done by default in recent JDK and JRE implementations. Because there are many different ways to disable external entity retrieval with varying support between different providers, in this query we choose to specifically check for the [OWASP recommended way](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java) to disable external entity retrieval for a particular parser. There may be other ways of making a particular parser safe which deviate from these guidelines, in which case this query will continue to flag the parser as potentially dangerous.\n\n\n## Example\nThe following example calls `parse` on a `DocumentBuilder` that is not safely configured on untrusted data, and is therefore inherently unsafe.\n\n\n```java\npublic void parse(Socket sock) throws Exception {\n  DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n  DocumentBuilder builder = factory.newDocumentBuilder();\n  builder.parse(sock.getInputStream()); //unsafe\n}\n\n```\nIn this example, the `DocumentBuilder` is created with DTD disabled, securing it against XXE attack.\n\n\n```java\npublic void disableDTDParse(Socket sock) throws Exception {\n  DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();\n  factory.setFeature(\"http://apache.org/xml/features/disallow-doctype-decl\", true);\n  DocumentBuilder builder = factory.newDocumentBuilder();\n  builder.parse(sock.getInputStream()); //safe\n}\n\n```\n\n## References\n* OWASP vulnerability description: [XML External Entity (XXE) Processing](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing).\n* OWASP guidance on parsing xml files: [XXE Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java).\n* Paper by Timothy Morgen: [XML Schema, DTD, and Entity Attacks](https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/)\n* Out-of-band data retrieval: Timur Yunusov &amp; Alexey Osipov, Black hat EU 2013: [XML Out-Of-Band Data Retrieval](https://www.slideshare.net/qqlan/bh-ready-v4).\n* Denial of service attack (Billion laughs): [Billion Laughs.](https://en.wikipedia.org/wiki/Billion_laughs)\n* The Java Tutorials: [Processing Limit Definitions.](https://docs.oracle.com/javase/tutorial/jaxp/limits/limits.html)\n* Common Weakness Enumeration: [CWE-611](https://cwe.mitre.org/data/definitions/611.html).\n* Common Weakness Enumeration: [CWE-776](https://cwe.mitre.org/data/definitions/776.html).\n* Common Weakness Enumeration: [CWE-827](https://cwe.mitre.org/data/definitions/827.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-611",
+                                        "external/cwe/cwe-776",
+                                        "external/cwe/cwe-827"
+                                    ],
+                                    "description": "Parsing user-controlled XML documents and allowing expansion of external entity\n references may lead to disclosure of confidential data or denial of service.",
+                                    "id": "java/xxe",
+                                    "kind": "path-problem",
+                                    "name": "Resolving XML external entity in user-controlled data",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.1"
+                                }
+                            },
+                            {
+                                "id": "java/polynomial-redos",
+                                "name": "java/polynomial-redos",
+                                "shortDescription": {
+                                    "text": "Polynomial regular expression used on uncontrolled data"
+                                },
+                                "fullDescription": {
+                                    "text": "A regular expression that can require polynomial time to match may be vulnerable to denial-of-service attacks."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Polynomial regular expression used on uncontrolled data\nSome regular expressions take a long time to match certain input strings to the point where the time it takes to match a string of length *n* is proportional to *n<sup>k</sup>* or even *2<sup>n</sup>*. Such regular expressions can negatively affect performance, or even allow a malicious user to perform a Denial of Service (\"DoS\") attack by crafting an expensive input string for the regular expression to match.\n\nThe regular expression engine provided by Java uses a backtracking non-deterministic finite automata to implement regular expression matching. While this approach is space-efficient and allows supporting advanced features like capture groups, it is not time-efficient in general. The worst-case time complexity of such an automaton can be polynomial or even exponential, meaning that for strings of a certain shape, increasing the input length by ten characters may make the automaton about 1000 times slower.\n\nTypically, a regular expression is affected by this problem if it contains a repetition of the form `r*` or `r+` where the sub-expression `r` is ambiguous in the sense that it can match some string in multiple ways. More information about the precise circumstances can be found in the references.\n\nNote that Java versions 9 and above have some mitigations against ReDoS; however they aren't perfect and more complex regular expressions can still be affected by this problem.\n\n\n## Recommendation\nModify the regular expression to remove the ambiguity, or ensure that the strings matched with the regular expression are short enough that the time-complexity does not matter. Alternatively, an alternate regex library that guarantees linear time execution, such as Google's RE2J, may be used.\n\n\n## Example\nConsider this use of a regular expression, which removes all leading and trailing whitespace in a string:\n\n```java\n\n\t\t\tPattern.compile(\"^\\\\s+|\\\\s+$\").matcher(text).replaceAll(\"\") // BAD\n\t\t\n```\nThe sub-expression `\"\\\\s+$\"` will match the whitespace characters in `text` from left to right, but it can start matching anywhere within a whitespace sequence. This is problematic for strings that do **not** end with a whitespace character. Such a string will force the regular expression engine to process each whitespace sequence once per whitespace character in the sequence.\n\nThis ultimately means that the time cost of trimming a string is quadratic in the length of the string. So a string like `\"a b\"` will take milliseconds to process, but a similar string with a million spaces instead of just one will take several minutes.\n\nAvoid this problem by rewriting the regular expression to not contain the ambiguity about when to start matching whitespace sequences. For instance, by using a negative look-behind (`\"^\\\\s+|(?<!\\\\s)\\\\s+$\"`), or just by using the built-in trim method (`text.trim()`).\n\nNote that the sub-expression `\"^\\\\s+\"` is **not** problematic as the `^` anchor restricts when that sub-expression can start matching, and as the regular expression engine matches from left to right.\n\n\n## Example\nAs a similar, but slightly subtler problem, consider the regular expression that matches lines with numbers, possibly written using scientific notation:\n\n```java\n\n\t\t\t\"^0\\\\.\\\\d+E?\\\\d+$\"\" \n\t\t\n```\nThe problem with this regular expression is in the sub-expression `\\d+E?\\d+` because the second `\\d+` can start matching digits anywhere after the first match of the first `\\d+` if there is no `E` in the input string.\n\nThis is problematic for strings that do **not** end with a digit. Such a string will force the regular expression engine to process each digit sequence once per digit in the sequence, again leading to a quadratic time complexity.\n\nTo make the processing faster, the regular expression should be rewritten such that the two `\\d+` sub-expressions do not have overlapping matches: `\"^0\\\\.\\\\d+(E\\\\d+)?$\"`.\n\n\n## References\n* OWASP: [Regular expression Denial of Service - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).\n* Wikipedia: [ReDoS](https://en.wikipedia.org/wiki/ReDoS).\n* Wikipedia: [Time complexity](https://en.wikipedia.org/wiki/Time_complexity).\n* James Kirrage, Asiri Rathnayake, Hayo Thielecke: [Static Analysis for Regular Expression Denial-of-Service Attack](http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf).\n* Common Weakness Enumeration: [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html).\n* Common Weakness Enumeration: [CWE-730](https://cwe.mitre.org/data/definitions/730.html).\n* Common Weakness Enumeration: [CWE-400](https://cwe.mitre.org/data/definitions/400.html).\n",
+                                    "markdown": "# Polynomial regular expression used on uncontrolled data\nSome regular expressions take a long time to match certain input strings to the point where the time it takes to match a string of length *n* is proportional to *n<sup>k</sup>* or even *2<sup>n</sup>*. Such regular expressions can negatively affect performance, or even allow a malicious user to perform a Denial of Service (\"DoS\") attack by crafting an expensive input string for the regular expression to match.\n\nThe regular expression engine provided by Java uses a backtracking non-deterministic finite automata to implement regular expression matching. While this approach is space-efficient and allows supporting advanced features like capture groups, it is not time-efficient in general. The worst-case time complexity of such an automaton can be polynomial or even exponential, meaning that for strings of a certain shape, increasing the input length by ten characters may make the automaton about 1000 times slower.\n\nTypically, a regular expression is affected by this problem if it contains a repetition of the form `r*` or `r+` where the sub-expression `r` is ambiguous in the sense that it can match some string in multiple ways. More information about the precise circumstances can be found in the references.\n\nNote that Java versions 9 and above have some mitigations against ReDoS; however they aren't perfect and more complex regular expressions can still be affected by this problem.\n\n\n## Recommendation\nModify the regular expression to remove the ambiguity, or ensure that the strings matched with the regular expression are short enough that the time-complexity does not matter. Alternatively, an alternate regex library that guarantees linear time execution, such as Google's RE2J, may be used.\n\n\n## Example\nConsider this use of a regular expression, which removes all leading and trailing whitespace in a string:\n\n```java\n\n\t\t\tPattern.compile(\"^\\\\s+|\\\\s+$\").matcher(text).replaceAll(\"\") // BAD\n\t\t\n```\nThe sub-expression `\"\\\\s+$\"` will match the whitespace characters in `text` from left to right, but it can start matching anywhere within a whitespace sequence. This is problematic for strings that do **not** end with a whitespace character. Such a string will force the regular expression engine to process each whitespace sequence once per whitespace character in the sequence.\n\nThis ultimately means that the time cost of trimming a string is quadratic in the length of the string. So a string like `\"a b\"` will take milliseconds to process, but a similar string with a million spaces instead of just one will take several minutes.\n\nAvoid this problem by rewriting the regular expression to not contain the ambiguity about when to start matching whitespace sequences. For instance, by using a negative look-behind (`\"^\\\\s+|(?<!\\\\s)\\\\s+$\"`), or just by using the built-in trim method (`text.trim()`).\n\nNote that the sub-expression `\"^\\\\s+\"` is **not** problematic as the `^` anchor restricts when that sub-expression can start matching, and as the regular expression engine matches from left to right.\n\n\n## Example\nAs a similar, but slightly subtler problem, consider the regular expression that matches lines with numbers, possibly written using scientific notation:\n\n```java\n\n\t\t\t\"^0\\\\.\\\\d+E?\\\\d+$\"\" \n\t\t\n```\nThe problem with this regular expression is in the sub-expression `\\d+E?\\d+` because the second `\\d+` can start matching digits anywhere after the first match of the first `\\d+` if there is no `E` in the input string.\n\nThis is problematic for strings that do **not** end with a digit. Such a string will force the regular expression engine to process each digit sequence once per digit in the sequence, again leading to a quadratic time complexity.\n\nTo make the processing faster, the regular expression should be rewritten such that the two `\\d+` sub-expressions do not have overlapping matches: `\"^0\\\\.\\\\d+(E\\\\d+)?$\"`.\n\n\n## References\n* OWASP: [Regular expression Denial of Service - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).\n* Wikipedia: [ReDoS](https://en.wikipedia.org/wiki/ReDoS).\n* Wikipedia: [Time complexity](https://en.wikipedia.org/wiki/Time_complexity).\n* James Kirrage, Asiri Rathnayake, Hayo Thielecke: [Static Analysis for Regular Expression Denial-of-Service Attack](http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf).\n* Common Weakness Enumeration: [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html).\n* Common Weakness Enumeration: [CWE-730](https://cwe.mitre.org/data/definitions/730.html).\n* Common Weakness Enumeration: [CWE-400](https://cwe.mitre.org/data/definitions/400.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-1333",
+                                        "external/cwe/cwe-730",
+                                        "external/cwe/cwe-400"
+                                    ],
+                                    "description": "A regular expression that can require polynomial time\n              to match may be vulnerable to denial-of-service attacks.",
+                                    "id": "java/polynomial-redos",
+                                    "kind": "path-problem",
+                                    "name": "Polynomial regular expression used on uncontrolled data",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/redos",
+                                "name": "java/redos",
+                                "shortDescription": {
+                                    "text": "Inefficient regular expression"
+                                },
+                                "fullDescription": {
+                                    "text": "A regular expression that requires exponential time to match certain inputs can be a performance bottleneck, and may be vulnerable to denial-of-service attacks."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Inefficient regular expression\nSome regular expressions take a long time to match certain input strings to the point where the time it takes to match a string of length *n* is proportional to *n<sup>k</sup>* or even *2<sup>n</sup>*. Such regular expressions can negatively affect performance, or even allow a malicious user to perform a Denial of Service (\"DoS\") attack by crafting an expensive input string for the regular expression to match.\n\nThe regular expression engine provided by Java uses a backtracking non-deterministic finite automata to implement regular expression matching. While this approach is space-efficient and allows supporting advanced features like capture groups, it is not time-efficient in general. The worst-case time complexity of such an automaton can be polynomial or even exponential, meaning that for strings of a certain shape, increasing the input length by ten characters may make the automaton about 1000 times slower.\n\nTypically, a regular expression is affected by this problem if it contains a repetition of the form `r*` or `r+` where the sub-expression `r` is ambiguous in the sense that it can match some string in multiple ways. More information about the precise circumstances can be found in the references.\n\nNote that Java versions 9 and above have some mitigations against ReDoS; however they aren't perfect and more complex regular expressions can still be affected by this problem.\n\n\n## Recommendation\nModify the regular expression to remove the ambiguity, or ensure that the strings matched with the regular expression are short enough that the time-complexity does not matter. Alternatively, an alternate regex library that guarantees linear time execution, such as Google's RE2J, may be used.\n\n\n## Example\nConsider this regular expression:\n\n```java\n\n\t\t\t^_(__|.)+_$\n\t\t\n```\nIts sub-expression `\"(__|.)+?\"` can match the string `\"__\"` either by the first alternative `\"__\"` to the left of the `\"|\"` operator, or by two repetitions of the second alternative `\".\"` to the right. Thus, a string consisting of an odd number of underscores followed by some other character will cause the regular expression engine to run for an exponential amount of time before rejecting the input.\n\nThis problem can be avoided by rewriting the regular expression to remove the ambiguity between the two branches of the alternative inside the repetition:\n\n```java\n\n\t\t\t^_(__|[^_])+_$\n\t\t\n```\n\n## References\n* OWASP: [Regular expression Denial of Service - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).\n* Wikipedia: [ReDoS](https://en.wikipedia.org/wiki/ReDoS).\n* Wikipedia: [Time complexity](https://en.wikipedia.org/wiki/Time_complexity).\n* James Kirrage, Asiri Rathnayake, Hayo Thielecke: [Static Analysis for Regular Expression Denial-of-Service Attack](http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf).\n* Common Weakness Enumeration: [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html).\n* Common Weakness Enumeration: [CWE-730](https://cwe.mitre.org/data/definitions/730.html).\n* Common Weakness Enumeration: [CWE-400](https://cwe.mitre.org/data/definitions/400.html).\n",
+                                    "markdown": "# Inefficient regular expression\nSome regular expressions take a long time to match certain input strings to the point where the time it takes to match a string of length *n* is proportional to *n<sup>k</sup>* or even *2<sup>n</sup>*. Such regular expressions can negatively affect performance, or even allow a malicious user to perform a Denial of Service (\"DoS\") attack by crafting an expensive input string for the regular expression to match.\n\nThe regular expression engine provided by Java uses a backtracking non-deterministic finite automata to implement regular expression matching. While this approach is space-efficient and allows supporting advanced features like capture groups, it is not time-efficient in general. The worst-case time complexity of such an automaton can be polynomial or even exponential, meaning that for strings of a certain shape, increasing the input length by ten characters may make the automaton about 1000 times slower.\n\nTypically, a regular expression is affected by this problem if it contains a repetition of the form `r*` or `r+` where the sub-expression `r` is ambiguous in the sense that it can match some string in multiple ways. More information about the precise circumstances can be found in the references.\n\nNote that Java versions 9 and above have some mitigations against ReDoS; however they aren't perfect and more complex regular expressions can still be affected by this problem.\n\n\n## Recommendation\nModify the regular expression to remove the ambiguity, or ensure that the strings matched with the regular expression are short enough that the time-complexity does not matter. Alternatively, an alternate regex library that guarantees linear time execution, such as Google's RE2J, may be used.\n\n\n## Example\nConsider this regular expression:\n\n```java\n\n\t\t\t^_(__|.)+_$\n\t\t\n```\nIts sub-expression `\"(__|.)+?\"` can match the string `\"__\"` either by the first alternative `\"__\"` to the left of the `\"|\"` operator, or by two repetitions of the second alternative `\".\"` to the right. Thus, a string consisting of an odd number of underscores followed by some other character will cause the regular expression engine to run for an exponential amount of time before rejecting the input.\n\nThis problem can be avoided by rewriting the regular expression to remove the ambiguity between the two branches of the alternative inside the repetition:\n\n```java\n\n\t\t\t^_(__|[^_])+_$\n\t\t\n```\n\n## References\n* OWASP: [Regular expression Denial of Service - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).\n* Wikipedia: [ReDoS](https://en.wikipedia.org/wiki/ReDoS).\n* Wikipedia: [Time complexity](https://en.wikipedia.org/wiki/Time_complexity).\n* James Kirrage, Asiri Rathnayake, Hayo Thielecke: [Static Analysis for Regular Expression Denial-of-Service Attack](http://www.cs.bham.ac.uk/~hxt/research/reg-exp-sec.pdf).\n* Common Weakness Enumeration: [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html).\n* Common Weakness Enumeration: [CWE-730](https://cwe.mitre.org/data/definitions/730.html).\n* Common Weakness Enumeration: [CWE-400](https://cwe.mitre.org/data/definitions/400.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-1333",
+                                        "external/cwe/cwe-730",
+                                        "external/cwe/cwe-400"
+                                    ],
+                                    "description": "A regular expression that requires exponential time to match certain inputs\n              can be a performance bottleneck, and may be vulnerable to denial-of-service\n              attacks.",
+                                    "id": "java/redos",
+                                    "kind": "problem",
+                                    "name": "Inefficient regular expression",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/regex-injection",
+                                "name": "java/regex-injection",
+                                "shortDescription": {
+                                    "text": "Regular expression injection"
+                                },
+                                "fullDescription": {
+                                    "text": "User input should not be used in regular expressions without first being escaped, otherwise a malicious user may be able to provide a regex that could require exponential time on certain inputs."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Regular expression injection\nConstructing a regular expression with unsanitized user input is dangerous as a malicious user may be able to modify the meaning of the expression. In particular, such a user may be able to provide a regular expression fragment that takes exponential time in the worst case, and use that to perform a Denial of Service attack.\n\n\n## Recommendation\nBefore embedding user input into a regular expression, use a sanitization function such as `Pattern.quote` to escape meta-characters that have special meaning.\n\n\n## Example\nThe following example shows an HTTP request parameter that is used to construct a regular expression.\n\nIn the first case the user-provided regex is not escaped. If a malicious user provides a regex whose worst-case performance is exponential, then this could lead to a Denial of Service.\n\nIn the second case, the user input is escaped using `Pattern.quote` before being included in the regular expression. This ensures that the user cannot insert characters which have a special meaning in regular expressions.\n\n\n```java\nimport java.util.regex.Pattern;\nimport javax.servlet.http.HttpServlet;\nimport javax.servlet.http.HttpServletRequest;\n\npublic class RegexInjectionDemo extends HttpServlet {\n\n  public boolean badExample(javax.servlet.http.HttpServletRequest request) {\n    String regex = request.getParameter(\"regex\");\n    String input = request.getParameter(\"input\");\n\n    // BAD: Unsanitized user input is used to construct a regular expression\n    return input.matches(regex);\n  }\n\n  public boolean goodExample(javax.servlet.http.HttpServletRequest request) {\n    String regex = request.getParameter(\"regex\");\n    String input = request.getParameter(\"input\");\n\n    // GOOD: User input is sanitized before constructing the regex\n    return input.matches(Pattern.quote(regex));\n  }\n}\n\n```\n\n## References\n* OWASP: [Regular expression Denial of Service - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).\n* Wikipedia: [ReDoS](https://en.wikipedia.org/wiki/ReDoS).\n* Java API Specification: [Pattern.quote](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#quote(java.lang.String)).\n* Common Weakness Enumeration: [CWE-730](https://cwe.mitre.org/data/definitions/730.html).\n* Common Weakness Enumeration: [CWE-400](https://cwe.mitre.org/data/definitions/400.html).\n",
+                                    "markdown": "# Regular expression injection\nConstructing a regular expression with unsanitized user input is dangerous as a malicious user may be able to modify the meaning of the expression. In particular, such a user may be able to provide a regular expression fragment that takes exponential time in the worst case, and use that to perform a Denial of Service attack.\n\n\n## Recommendation\nBefore embedding user input into a regular expression, use a sanitization function such as `Pattern.quote` to escape meta-characters that have special meaning.\n\n\n## Example\nThe following example shows an HTTP request parameter that is used to construct a regular expression.\n\nIn the first case the user-provided regex is not escaped. If a malicious user provides a regex whose worst-case performance is exponential, then this could lead to a Denial of Service.\n\nIn the second case, the user input is escaped using `Pattern.quote` before being included in the regular expression. This ensures that the user cannot insert characters which have a special meaning in regular expressions.\n\n\n```java\nimport java.util.regex.Pattern;\nimport javax.servlet.http.HttpServlet;\nimport javax.servlet.http.HttpServletRequest;\n\npublic class RegexInjectionDemo extends HttpServlet {\n\n  public boolean badExample(javax.servlet.http.HttpServletRequest request) {\n    String regex = request.getParameter(\"regex\");\n    String input = request.getParameter(\"input\");\n\n    // BAD: Unsanitized user input is used to construct a regular expression\n    return input.matches(regex);\n  }\n\n  public boolean goodExample(javax.servlet.http.HttpServletRequest request) {\n    String regex = request.getParameter(\"regex\");\n    String input = request.getParameter(\"input\");\n\n    // GOOD: User input is sanitized before constructing the regex\n    return input.matches(Pattern.quote(regex));\n  }\n}\n\n```\n\n## References\n* OWASP: [Regular expression Denial of Service - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS).\n* Wikipedia: [ReDoS](https://en.wikipedia.org/wiki/ReDoS).\n* Java API Specification: [Pattern.quote](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html#quote(java.lang.String)).\n* Common Weakness Enumeration: [CWE-730](https://cwe.mitre.org/data/definitions/730.html).\n* Common Weakness Enumeration: [CWE-400](https://cwe.mitre.org/data/definitions/400.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-730",
+                                        "external/cwe/cwe-400"
+                                    ],
+                                    "description": "User input should not be used in regular expressions without first being escaped,\n              otherwise a malicious user may be able to provide a regex that could require\n              exponential time on certain inputs.",
+                                    "id": "java/regex-injection",
+                                    "kind": "path-problem",
+                                    "name": "Regular expression injection",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/android/unsafe-content-uri-resolution",
+                                "name": "java/android/unsafe-content-uri-resolution",
+                                "shortDescription": {
+                                    "text": "Uncontrolled data used in content resolution"
+                                },
+                                "fullDescription": {
+                                    "text": "Resolving externally-provided content URIs without validation can allow an attacker to access unexpected resources."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Uncontrolled data used in content resolution\nWhen an Android application wants to access data in a content provider, it uses the `ContentResolver` object. `ContentResolver`s communicate with an instance of a class that implements the `ContentProvider` interface via URIs with the `content://` scheme. The authority part (the first path segment) of the URI, passed as parameter to the `ContentResolver`, determines which content provider is contacted for the operation. Specific operations that act on files also support the `file://` scheme, in which case the local filesystem is queried instead. If an external component, like a malicious or compromised application, controls the URI for a `ContentResolver` operation, it can trick the vulnerable application into accessing its own private files or non-exported content providers. The attacking application might be able to get access to the file by forcing it to be copied to a public directory, like external storage, or tamper with the contents by making the application overwrite the file with unexpected data.\n\n\n## Recommendation\nIf possible, avoid using externally-provided data to determine the URI for a `ContentResolver` to use. If that is not an option, validate that the incoming URI can only reference trusted components, like an allow list of content providers and/or applications, or alternatively make sure that the URI does not reference private directories like `/data/`.\n\n\n## Example\nThis example shows three ways of opening a file using a `ContentResolver`. In the first case, externally-provided data from an intent is used directly in the file-reading operation. This allows an attacker to provide a URI of the form `/data/data/(vulnerable app package)/(private file)` to trick the application into reading it and copying it to the external storage. In the second case, an insufficient check is performed on the externally-provided URI, still leaving room for exploitation. In the third case, the URI is correctly validated before being used, making sure it does not reference any internal application files.\n\n\n```java\nimport android.content.ContentResolver;\nimport android.net.Uri;\n\npublic class Example extends Activity {\n    public void onCreate() {\n        // BAD: Externally-provided URI directly used in content resolution\n        {\n            ContentResolver contentResolver = getContentResolver();\n            Uri uri = (Uri) getIntent().getParcelableExtra(\"URI_EXTRA\");\n            InputStream is = contentResolver.openInputStream(uri);\n            copyToExternalCache(is);\n        }\n        // BAD: input URI is not normalized, and check can be bypassed with \"..\" characters\n        {\n            ContentResolver contentResolver = getContentResolver();\n            Uri uri = (Uri) getIntent().getParcelableExtra(\"URI_EXTRA\");\n            String path = uri.getPath();\n            if (path.startsWith(\"/data\"))\n                throw new SecurityException();\n            InputStream is = contentResolver.openInputStream(uri);\n            copyToExternalCache(is);\n        }\n        // GOOD: URI is properly validated to block access to internal files\n        {\n            ContentResolver contentResolver = getContentResolver();\n            Uri uri = (Uri) getIntent().getParcelableExtra(\"URI_EXTRA\");\n            String path = uri.getPath();\n            java.nio.file.Path normalized =\n                    java.nio.file.FileSystems.getDefault().getPath(path).normalize();\n            if (normalized.startsWith(\"/data\"))\n                throw new SecurityException();\n            InputStream is = contentResolver.openInputStream(uri);\n            copyToExternalCache(is);\n        }\n    }\n\n    private void copyToExternalCache(InputStream is) {\n        // Reads the contents of is and writes a file in the app's external\n        // cache directory, which can be read publicly by applications in the same device.\n    }\n}\n\n```\n\n## References\n* Android developers: [Content provider basics](https://developer.android.com/guide/topics/providers/content-provider-basics)\n* [The ContentResolver class](https://developer.android.com/reference/android/content/ContentResolver)\n* Common Weakness Enumeration: [CWE-441](https://cwe.mitre.org/data/definitions/441.html).\n* Common Weakness Enumeration: [CWE-610](https://cwe.mitre.org/data/definitions/610.html).\n",
+                                    "markdown": "# Uncontrolled data used in content resolution\nWhen an Android application wants to access data in a content provider, it uses the `ContentResolver` object. `ContentResolver`s communicate with an instance of a class that implements the `ContentProvider` interface via URIs with the `content://` scheme. The authority part (the first path segment) of the URI, passed as parameter to the `ContentResolver`, determines which content provider is contacted for the operation. Specific operations that act on files also support the `file://` scheme, in which case the local filesystem is queried instead. If an external component, like a malicious or compromised application, controls the URI for a `ContentResolver` operation, it can trick the vulnerable application into accessing its own private files or non-exported content providers. The attacking application might be able to get access to the file by forcing it to be copied to a public directory, like external storage, or tamper with the contents by making the application overwrite the file with unexpected data.\n\n\n## Recommendation\nIf possible, avoid using externally-provided data to determine the URI for a `ContentResolver` to use. If that is not an option, validate that the incoming URI can only reference trusted components, like an allow list of content providers and/or applications, or alternatively make sure that the URI does not reference private directories like `/data/`.\n\n\n## Example\nThis example shows three ways of opening a file using a `ContentResolver`. In the first case, externally-provided data from an intent is used directly in the file-reading operation. This allows an attacker to provide a URI of the form `/data/data/(vulnerable app package)/(private file)` to trick the application into reading it and copying it to the external storage. In the second case, an insufficient check is performed on the externally-provided URI, still leaving room for exploitation. In the third case, the URI is correctly validated before being used, making sure it does not reference any internal application files.\n\n\n```java\nimport android.content.ContentResolver;\nimport android.net.Uri;\n\npublic class Example extends Activity {\n    public void onCreate() {\n        // BAD: Externally-provided URI directly used in content resolution\n        {\n            ContentResolver contentResolver = getContentResolver();\n            Uri uri = (Uri) getIntent().getParcelableExtra(\"URI_EXTRA\");\n            InputStream is = contentResolver.openInputStream(uri);\n            copyToExternalCache(is);\n        }\n        // BAD: input URI is not normalized, and check can be bypassed with \"..\" characters\n        {\n            ContentResolver contentResolver = getContentResolver();\n            Uri uri = (Uri) getIntent().getParcelableExtra(\"URI_EXTRA\");\n            String path = uri.getPath();\n            if (path.startsWith(\"/data\"))\n                throw new SecurityException();\n            InputStream is = contentResolver.openInputStream(uri);\n            copyToExternalCache(is);\n        }\n        // GOOD: URI is properly validated to block access to internal files\n        {\n            ContentResolver contentResolver = getContentResolver();\n            Uri uri = (Uri) getIntent().getParcelableExtra(\"URI_EXTRA\");\n            String path = uri.getPath();\n            java.nio.file.Path normalized =\n                    java.nio.file.FileSystems.getDefault().getPath(path).normalize();\n            if (normalized.startsWith(\"/data\"))\n                throw new SecurityException();\n            InputStream is = contentResolver.openInputStream(uri);\n            copyToExternalCache(is);\n        }\n    }\n\n    private void copyToExternalCache(InputStream is) {\n        // Reads the contents of is and writes a file in the app's external\n        // cache directory, which can be read publicly by applications in the same device.\n    }\n}\n\n```\n\n## References\n* Android developers: [Content provider basics](https://developer.android.com/guide/topics/providers/content-provider-basics)\n* [The ContentResolver class](https://developer.android.com/reference/android/content/ContentResolver)\n* Common Weakness Enumeration: [CWE-441](https://cwe.mitre.org/data/definitions/441.html).\n* Common Weakness Enumeration: [CWE-610](https://cwe.mitre.org/data/definitions/610.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-441",
+                                        "external/cwe/cwe-610"
+                                    ],
+                                    "description": "Resolving externally-provided content URIs without validation can allow an attacker\n              to access unexpected resources.",
+                                    "id": "java/android/unsafe-content-uri-resolution",
+                                    "kind": "path-problem",
+                                    "name": "Uncontrolled data used in content resolution",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/cleartext-storage-in-cookie",
+                                "name": "java/cleartext-storage-in-cookie",
+                                "shortDescription": {
+                                    "text": "Cleartext storage of sensitive information in cookie"
+                                },
+                                "fullDescription": {
+                                    "text": "Storing sensitive information in cleartext can expose it to an attacker."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Cleartext storage of sensitive information in cookie\nSensitive information that is stored unencrypted is accessible to an attacker who gains access to the storage.\n\n\n## Recommendation\nEnsure that sensitive information is always encrypted before being stored. It may be wise to encrypt information before it is put into a heap data structure (such as `Java.util.Properties`) that may be written to disk later. Objects that are serializable or marshallable should also always contain encrypted information unless you are certain that they are not ever going to be serialized.\n\nIn general, decrypt sensitive information only at the point where it is necessary for it to be used in cleartext.\n\n\n## Example\nThe following example shows two ways of storing user credentials in a cookie. In the 'BAD' case, the credentials are simply stored in cleartext. In the 'GOOD' case, the credentials are hashed before storing them.\n\n\n```java\npublic static void main(String[] args) {\n\t{\n\t\tString data;\n\t\tPasswordAuthentication credentials =\n\t\t\t\tnew PasswordAuthentication(\"user\", \"BP@ssw0rd\".toCharArray());\n\t\tdata = credentials.getUserName() + \":\" + new String(credentials.getPassword());\n\t\n\t\t// BAD: store data in a cookie in cleartext form\n\t\tresponse.addCookie(new Cookie(\"auth\", data));\n\t}\n\t\n\t{\n\t\tString data;\n\t\tPasswordAuthentication credentials =\n\t\t\t\tnew PasswordAuthentication(\"user\", \"GP@ssw0rd\".toCharArray());\n\t\tString salt = \"ThisIsMySalt\";\n\t\tMessageDigest messageDigest = MessageDigest.getInstance(\"SHA-512\");\n\t\tmessageDigest.reset();\n\t\tString credentialsToHash =\n\t\t\t\tcredentials.getUserName() + \":\" + credentials.getPassword();\n\t\tbyte[] hashedCredsAsBytes =\n\t\t\t\tmessageDigest.digest((salt+credentialsToHash).getBytes(\"UTF-8\"));\n\t\tdata = bytesToString(hashedCredsAsBytes);\n\t\t\n\t\t// GOOD: store data in a cookie in encrypted form\n\t\tresponse.addCookie(new Cookie(\"auth\", data));\n\t}\n}\n\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [SER03-J. Do not serialize unencrypted, sensitive data](https://wiki.sei.cmu.edu/confluence/display/java/SER03-J.+Do+not+serialize+unencrypted+sensitive+data).\n* M. Dowd, J. McDonald and J. Schuhm, *The Art of Software Security Assessment*, 1st Edition, Chapter 2 - 'Common Vulnerabilities of Encryption', p. 43. Addison Wesley, 2006.\n* M. Howard and D. LeBlanc, *Writing Secure Code*, 2nd Edition, Chapter 9 - 'Protecting Secret Data', p. 299. Microsoft, 2002.\n* Common Weakness Enumeration: [CWE-315](https://cwe.mitre.org/data/definitions/315.html).\n",
+                                    "markdown": "# Cleartext storage of sensitive information in cookie\nSensitive information that is stored unencrypted is accessible to an attacker who gains access to the storage.\n\n\n## Recommendation\nEnsure that sensitive information is always encrypted before being stored. It may be wise to encrypt information before it is put into a heap data structure (such as `Java.util.Properties`) that may be written to disk later. Objects that are serializable or marshallable should also always contain encrypted information unless you are certain that they are not ever going to be serialized.\n\nIn general, decrypt sensitive information only at the point where it is necessary for it to be used in cleartext.\n\n\n## Example\nThe following example shows two ways of storing user credentials in a cookie. In the 'BAD' case, the credentials are simply stored in cleartext. In the 'GOOD' case, the credentials are hashed before storing them.\n\n\n```java\npublic static void main(String[] args) {\n\t{\n\t\tString data;\n\t\tPasswordAuthentication credentials =\n\t\t\t\tnew PasswordAuthentication(\"user\", \"BP@ssw0rd\".toCharArray());\n\t\tdata = credentials.getUserName() + \":\" + new String(credentials.getPassword());\n\t\n\t\t// BAD: store data in a cookie in cleartext form\n\t\tresponse.addCookie(new Cookie(\"auth\", data));\n\t}\n\t\n\t{\n\t\tString data;\n\t\tPasswordAuthentication credentials =\n\t\t\t\tnew PasswordAuthentication(\"user\", \"GP@ssw0rd\".toCharArray());\n\t\tString salt = \"ThisIsMySalt\";\n\t\tMessageDigest messageDigest = MessageDigest.getInstance(\"SHA-512\");\n\t\tmessageDigest.reset();\n\t\tString credentialsToHash =\n\t\t\t\tcredentials.getUserName() + \":\" + credentials.getPassword();\n\t\tbyte[] hashedCredsAsBytes =\n\t\t\t\tmessageDigest.digest((salt+credentialsToHash).getBytes(\"UTF-8\"));\n\t\tdata = bytesToString(hashedCredsAsBytes);\n\t\t\n\t\t// GOOD: store data in a cookie in encrypted form\n\t\tresponse.addCookie(new Cookie(\"auth\", data));\n\t}\n}\n\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [SER03-J. Do not serialize unencrypted, sensitive data](https://wiki.sei.cmu.edu/confluence/display/java/SER03-J.+Do+not+serialize+unencrypted+sensitive+data).\n* M. Dowd, J. McDonald and J. Schuhm, *The Art of Software Security Assessment*, 1st Edition, Chapter 2 - 'Common Vulnerabilities of Encryption', p. 43. Addison Wesley, 2006.\n* M. Howard and D. LeBlanc, *Writing Secure Code*, 2nd Edition, Chapter 9 - 'Protecting Secret Data', p. 299. Microsoft, 2002.\n* Common Weakness Enumeration: [CWE-315](https://cwe.mitre.org/data/definitions/315.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-315"
+                                    ],
+                                    "description": "Storing sensitive information in cleartext can expose it to an attacker.",
+                                    "id": "java/cleartext-storage-in-cookie",
+                                    "kind": "problem",
+                                    "name": "Cleartext storage of sensitive information in cookie",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "5.0"
+                                }
+                            },
+                            {
+                                "id": "java/tainted-permissions-check",
+                                "name": "java/tainted-permissions-check",
+                                "shortDescription": {
+                                    "text": "User-controlled data used in permissions check"
+                                },
+                                "fullDescription": {
+                                    "text": "Using user-controlled data in a permissions check may result in inappropriate permissions being granted."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# User-controlled data used in permissions check\nUsing user-controlled data in a permissions check may allow a user to gain unauthorized access to protected functionality or data.\n\n\n## Recommendation\nWhen checking whether a user is authorized for a particular activity, do not use data that is controlled by that user in the permissions check. If necessary, always validate the input, ideally against a fixed list of expected values.\n\nSimilarly, do not decide which permission to check for based on user data. In particular, avoid using computation to decide which permissions to check for. Use fixed permissions for particular actions, rather than generating the permission to check for.\n\n\n## Example\nThis example, using the Apache Shiro security framework, shows two ways to specify the permissions to check. The first way uses a string, `whatDoTheyWantToDo`, to specify the permissions to check. However, this string is built from user input. This can allow an attacker to force a check against a permission that they know they have, rather than the permission that should be checked. For example, while trying to access the account details of another user, the attacker could force the system to check whether they had permissions to access their *own* account details, which is incorrect, and would allow them to perform the action. The second, more secure way uses a fixed check that does not depend on data that is controlled by the user.\n\n\n```java\npublic static void main(String[] args) {\n\tString whatDoTheyWantToDo = args[0];\n\tSubject subject = SecurityUtils.getSubject();\n\n\t// BAD: permissions decision made using tainted data\n\tif(subject.isPermitted(\"domain:sublevel:\" + whatDoTheyWantToDo))\n\t\tdoIt();\n\n\t// GOOD: use fixed checks\n\tif(subject.isPermitted(\"domain:sublevel:whatTheMethodDoes\"))\n\t\tdoIt();\n}\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [SEC02-J. Do not base security checks on untrusted sources](https://wiki.sei.cmu.edu/confluence/display/java/SEC02-J.+Do+not+base+security+checks+on+untrusted+sources).\n* Common Weakness Enumeration: [CWE-807](https://cwe.mitre.org/data/definitions/807.html).\n* Common Weakness Enumeration: [CWE-290](https://cwe.mitre.org/data/definitions/290.html).\n",
+                                    "markdown": "# User-controlled data used in permissions check\nUsing user-controlled data in a permissions check may allow a user to gain unauthorized access to protected functionality or data.\n\n\n## Recommendation\nWhen checking whether a user is authorized for a particular activity, do not use data that is controlled by that user in the permissions check. If necessary, always validate the input, ideally against a fixed list of expected values.\n\nSimilarly, do not decide which permission to check for based on user data. In particular, avoid using computation to decide which permissions to check for. Use fixed permissions for particular actions, rather than generating the permission to check for.\n\n\n## Example\nThis example, using the Apache Shiro security framework, shows two ways to specify the permissions to check. The first way uses a string, `whatDoTheyWantToDo`, to specify the permissions to check. However, this string is built from user input. This can allow an attacker to force a check against a permission that they know they have, rather than the permission that should be checked. For example, while trying to access the account details of another user, the attacker could force the system to check whether they had permissions to access their *own* account details, which is incorrect, and would allow them to perform the action. The second, more secure way uses a fixed check that does not depend on data that is controlled by the user.\n\n\n```java\npublic static void main(String[] args) {\n\tString whatDoTheyWantToDo = args[0];\n\tSubject subject = SecurityUtils.getSubject();\n\n\t// BAD: permissions decision made using tainted data\n\tif(subject.isPermitted(\"domain:sublevel:\" + whatDoTheyWantToDo))\n\t\tdoIt();\n\n\t// GOOD: use fixed checks\n\tif(subject.isPermitted(\"domain:sublevel:whatTheMethodDoes\"))\n\t\tdoIt();\n}\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [SEC02-J. Do not base security checks on untrusted sources](https://wiki.sei.cmu.edu/confluence/display/java/SEC02-J.+Do+not+base+security+checks+on+untrusted+sources).\n* Common Weakness Enumeration: [CWE-807](https://cwe.mitre.org/data/definitions/807.html).\n* Common Weakness Enumeration: [CWE-290](https://cwe.mitre.org/data/definitions/290.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-807",
+                                        "external/cwe/cwe-290"
+                                    ],
+                                    "description": "Using user-controlled data in a permissions check may result in inappropriate\n              permissions being granted.",
+                                    "id": "java/tainted-permissions-check",
+                                    "kind": "path-problem",
+                                    "name": "User-controlled data used in permissions check",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.8"
+                                }
+                            },
+                            {
+                                "id": "java/maven/non-https-url",
+                                "name": "java/maven/non-https-url",
+                                "shortDescription": {
+                                    "text": "Failure to use HTTPS or SFTP URL in Maven artifact upload/download"
+                                },
+                                "fullDescription": {
+                                    "text": "Non-HTTPS connections can be intercepted by third parties."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Failure to use HTTPS or SFTP URL in Maven artifact upload/download\nUsing an insecure protocol like HTTP or FTP to download your dependencies leaves your Maven build vulnerable to a [Man in the Middle (MITM)](https://en.wikipedia.org/wiki/Man-in-the-middle_attack). This can allow attackers to inject malicious code into the artifacts that you are resolving and infect build artifacts that are being produced. This can be used by attackers to perform a [Supply chain attack](https://en.wikipedia.org/wiki/Supply_chain_attack) against your project's users.\n\nThis vulnerability has a [ CVSS v3.1 base score of 8.1/10 ](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1).\n\n\n## Recommendation\nAlways use HTTPS or SFTP to download artifacts from artifact servers.\n\n\n## Example\nThese examples show examples of locations in Maven POM files where artifact repository upload/download is configured. The first shows the use of HTTP, the second shows the use of HTTPS.\n\n\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n\n    <modelVersion>4.0.0</modelVersion>\n\n    <groupId>com.semmle</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n    <packaging>pom</packaging>\n\n    <name>Security Testing</name>\n    <description>An example of insecure download and upload of dependencies</description>\n\n    <distributionManagement>\n        <repository>\n            <id>insecure-releases</id>\n            <name>Insecure Repository Releases</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </repository>\n        <snapshotRepository>\n            <id>insecure-snapshots</id>\n            <name>Insecure Repository Snapshots</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </snapshotRepository>\n    </distributionManagement>\n    <repositories>\n        <repository>\n            <id>insecure</id>\n            <name>Insecure Repository</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </repository>\n    </repositories>\n    <pluginRepositories>\n        <pluginRepository>\n            <id>insecure-plugins</id>\n            <name>Insecure Repository Releases</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </pluginRepository>\n    </pluginRepositories>\n</project>\n\n```\n\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n\n    <modelVersion>4.0.0</modelVersion>\n\n    <groupId>com.semmle</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n    <packaging>pom</packaging>\n\n    <name>Security Testing</name>\n    <description>An example of secure download and upload of dependencies</description>\n\n    <distributionManagement>\n        <repository>\n            <id>insecure-releases</id>\n            <name>Secure Repository Releases</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </repository>\n        <snapshotRepository>\n            <id>insecure-snapshots</id>\n            <name>Secure Repository Snapshots</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </snapshotRepository>\n    </distributionManagement>\n    <repositories>\n        <repository>\n            <id>insecure</id>\n            <name>Secure Repository</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </repository>\n    </repositories>\n    <pluginRepositories>\n        <pluginRepository>\n            <id>insecure-plugins</id>\n            <name>Secure Repository Releases</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </pluginRepository>\n    </pluginRepositories>\n</project>\n\n```\n\n## References\n* Research: [ Want to take over the Java ecosystem? All you need is a MITM! ](https://medium.com/bugbountywriteup/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)\n* Research: [ How to take over the computer of any Java (or Closure or Scala) Developer. ](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/)\n* Proof of Concept: [ mveytsman/dilettante ](https://github.com/mveytsman/dilettante)\n* Additional Gradle &amp; Maven plugin: [ Announcing nohttp ](https://spring.io/blog/2019/06/10/announcing-nohttp)\n* Java Ecosystem Announcement: [ HTTP Decommission Artifact Server Announcements ](https://gist.github.com/JLLeitschuh/789e49e3d34092a005031a0a1880af99)\n* Common Weakness Enumeration: [CWE-300](https://cwe.mitre.org/data/definitions/300.html).\n* Common Weakness Enumeration: [CWE-319](https://cwe.mitre.org/data/definitions/319.html).\n* Common Weakness Enumeration: [CWE-494](https://cwe.mitre.org/data/definitions/494.html).\n* Common Weakness Enumeration: [CWE-829](https://cwe.mitre.org/data/definitions/829.html).\n",
+                                    "markdown": "# Failure to use HTTPS or SFTP URL in Maven artifact upload/download\nUsing an insecure protocol like HTTP or FTP to download your dependencies leaves your Maven build vulnerable to a [Man in the Middle (MITM)](https://en.wikipedia.org/wiki/Man-in-the-middle_attack). This can allow attackers to inject malicious code into the artifacts that you are resolving and infect build artifacts that are being produced. This can be used by attackers to perform a [Supply chain attack](https://en.wikipedia.org/wiki/Supply_chain_attack) against your project's users.\n\nThis vulnerability has a [ CVSS v3.1 base score of 8.1/10 ](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.1).\n\n\n## Recommendation\nAlways use HTTPS or SFTP to download artifacts from artifact servers.\n\n\n## Example\nThese examples show examples of locations in Maven POM files where artifact repository upload/download is configured. The first shows the use of HTTP, the second shows the use of HTTPS.\n\n\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n\n    <modelVersion>4.0.0</modelVersion>\n\n    <groupId>com.semmle</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n    <packaging>pom</packaging>\n\n    <name>Security Testing</name>\n    <description>An example of insecure download and upload of dependencies</description>\n\n    <distributionManagement>\n        <repository>\n            <id>insecure-releases</id>\n            <name>Insecure Repository Releases</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </repository>\n        <snapshotRepository>\n            <id>insecure-snapshots</id>\n            <name>Insecure Repository Snapshots</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </snapshotRepository>\n    </distributionManagement>\n    <repositories>\n        <repository>\n            <id>insecure</id>\n            <name>Insecure Repository</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </repository>\n    </repositories>\n    <pluginRepositories>\n        <pluginRepository>\n            <id>insecure-plugins</id>\n            <name>Insecure Repository Releases</name>\n            <!-- BAD! Use HTTPS -->\n            <url>http://insecure-repository.example</url>\n        </pluginRepository>\n    </pluginRepositories>\n</project>\n\n```\n\n```xml\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n\n    <modelVersion>4.0.0</modelVersion>\n\n    <groupId>com.semmle</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n    <packaging>pom</packaging>\n\n    <name>Security Testing</name>\n    <description>An example of secure download and upload of dependencies</description>\n\n    <distributionManagement>\n        <repository>\n            <id>insecure-releases</id>\n            <name>Secure Repository Releases</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </repository>\n        <snapshotRepository>\n            <id>insecure-snapshots</id>\n            <name>Secure Repository Snapshots</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </snapshotRepository>\n    </distributionManagement>\n    <repositories>\n        <repository>\n            <id>insecure</id>\n            <name>Secure Repository</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </repository>\n    </repositories>\n    <pluginRepositories>\n        <pluginRepository>\n            <id>insecure-plugins</id>\n            <name>Secure Repository Releases</name>\n            <!-- GOOD! Use HTTPS -->\n            <url>https://insecure-repository.example</url>\n        </pluginRepository>\n    </pluginRepositories>\n</project>\n\n```\n\n## References\n* Research: [ Want to take over the Java ecosystem? All you need is a MITM! ](https://medium.com/bugbountywriteup/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)\n* Research: [ How to take over the computer of any Java (or Closure or Scala) Developer. ](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/)\n* Proof of Concept: [ mveytsman/dilettante ](https://github.com/mveytsman/dilettante)\n* Additional Gradle &amp; Maven plugin: [ Announcing nohttp ](https://spring.io/blog/2019/06/10/announcing-nohttp)\n* Java Ecosystem Announcement: [ HTTP Decommission Artifact Server Announcements ](https://gist.github.com/JLLeitschuh/789e49e3d34092a005031a0a1880af99)\n* Common Weakness Enumeration: [CWE-300](https://cwe.mitre.org/data/definitions/300.html).\n* Common Weakness Enumeration: [CWE-319](https://cwe.mitre.org/data/definitions/319.html).\n* Common Weakness Enumeration: [CWE-494](https://cwe.mitre.org/data/definitions/494.html).\n* Common Weakness Enumeration: [CWE-829](https://cwe.mitre.org/data/definitions/829.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-300",
+                                        "external/cwe/cwe-319",
+                                        "external/cwe/cwe-494",
+                                        "external/cwe/cwe-829"
+                                    ],
+                                    "description": "Non-HTTPS connections can be intercepted by third parties.",
+                                    "id": "java/maven/non-https-url",
+                                    "kind": "problem",
+                                    "name": "Failure to use HTTPS or SFTP URL in Maven artifact upload/download",
+                                    "precision": "very-high",
+                                    "problem.severity": "error",
+                                    "security-severity": "8.1"
+                                }
+                            },
+                            {
+                                "id": "java/android/webview-debugging-enabled",
+                                "name": "java/android/webview-debugging-enabled",
+                                "shortDescription": {
+                                    "text": "Android Webview debugging enabled"
+                                },
+                                "fullDescription": {
+                                    "text": "Enabling Webview debugging in production builds can expose entry points or leak sensitive information."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Android Webview debugging enabled\nThe `WebView.setWebContentsDebuggingEnabled` method enables or disables the contents of any `WebView` in the application to be debugged.\n\nYou should only enable debugging features during development. When you create a production build, you should disable it. If you enable debugging features, this can make your code vulnerable by adding entry points, or leaking sensitive information.\n\n\n## Recommendation\nEnsure that debugging features are not enabled in production builds, such as by guarding calls to `WebView.setWebContentsDebuggingEnabled(true)` by a flag that is only enabled in debug builds.\n\n\n## Example\nIn the first (bad) example, WebView debugging is always enabled. whereas the GOOD case only enables it if the `android:debuggable` attribute is set to `true`.\n\n\n```java\n// BAD - debugging is always enabled \nWebView.setWebContentsDebuggingEnabled(true);\n\n// GOOD - debugging is only enabled when this is a debug build, as indicated by the debuggable flag being set.\nif (0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {\n    WebView.setWebContentsDebuggingEnabled(true);\n}\n```\n\n## References\n* Android Developers: [setWebContentsDebuggingEnabled](https://developer.android.com/reference/android/webkit/WebView.html#setWebContentsDebuggingEnabled(boolean)).\n* Android Developers: [Remote debugging WebViews](https://developer.chrome.com/docs/devtools/remote-debugging/webviews/).\n* Common Weakness Enumeration: [CWE-489](https://cwe.mitre.org/data/definitions/489.html).\n",
+                                    "markdown": "# Android Webview debugging enabled\nThe `WebView.setWebContentsDebuggingEnabled` method enables or disables the contents of any `WebView` in the application to be debugged.\n\nYou should only enable debugging features during development. When you create a production build, you should disable it. If you enable debugging features, this can make your code vulnerable by adding entry points, or leaking sensitive information.\n\n\n## Recommendation\nEnsure that debugging features are not enabled in production builds, such as by guarding calls to `WebView.setWebContentsDebuggingEnabled(true)` by a flag that is only enabled in debug builds.\n\n\n## Example\nIn the first (bad) example, WebView debugging is always enabled. whereas the GOOD case only enables it if the `android:debuggable` attribute is set to `true`.\n\n\n```java\n// BAD - debugging is always enabled \nWebView.setWebContentsDebuggingEnabled(true);\n\n// GOOD - debugging is only enabled when this is a debug build, as indicated by the debuggable flag being set.\nif (0 != (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE)) {\n    WebView.setWebContentsDebuggingEnabled(true);\n}\n```\n\n## References\n* Android Developers: [setWebContentsDebuggingEnabled](https://developer.android.com/reference/android/webkit/WebView.html#setWebContentsDebuggingEnabled(boolean)).\n* Android Developers: [Remote debugging WebViews](https://developer.chrome.com/docs/devtools/remote-debugging/webviews/).\n* Common Weakness Enumeration: [CWE-489](https://cwe.mitre.org/data/definitions/489.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-489"
+                                    ],
+                                    "description": "Enabling Webview debugging in production builds can expose entry points or leak sensitive information.",
+                                    "id": "java/android/webview-debugging-enabled",
+                                    "kind": "path-problem",
+                                    "name": "Android Webview debugging enabled",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.2"
+                                }
+                            },
+                            {
+                                "id": "java/android/debuggable-attribute-enabled",
+                                "name": "java/android/debuggable-attribute-enabled",
+                                "shortDescription": {
+                                    "text": "Android debuggable attribute enabled"
+                                },
+                                "fullDescription": {
+                                    "text": "An enabled debugger can allow for entry points in the application or reveal sensitive information."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Android debuggable attribute enabled\nThe Android manifest file defines configuration settings for Android applications. In this file, the `android:debuggable` attribute of the `application` element can be used to define whether or not the application can be debugged. When set to `true`, this attribute will allow the application to be debugged even when running on a device in user mode.\n\nWhen a debugger is enabled, it could allow for entry points in the application or reveal sensitive information. As a result, `android:debuggable` should only be enabled during development and should be disabled in production builds.\n\n\n## Recommendation\nIn Android applications, either set the `android:debuggable` attribute to `false`, or do not include it in the manifest. The default value, when not included, is `false`.\n\n\n## Example\nIn the example below, the `android:debuggable` attribute is set to `true`.\n\n\n```xml\n<manifest ... >\n    <!-- BAD: 'android:debuggable' set to 'true' -->\n    <application\n        android:debuggable=\"true\">\n        <activity ... >\n        </activity>\n    </application>\n</manifest>\n\n```\nThe corrected version sets the `android:debuggable` attribute to `false`.\n\n\n```xml\n<manifest ... >\n    <!-- GOOD: 'android:debuggable' set to 'false' -->\n    <application\n        android:debuggable=\"false\">\n        <activity ... >\n        </activity>\n    </application>\n</manifest>\n\n```\n\n## References\n* Android Developers: [App Manifest Overview](https://developer.android.com/guide/topics/manifest/manifest-intro).\n* Android Developers: [The android:debuggable attribute](https://developer.android.com/guide/topics/manifest/application-element#debug).\n* Android Developers: [Enable debugging](https://developer.android.com/studio/debug#enable-debug).\n* Common Weakness Enumeration: [CWE-489](https://cwe.mitre.org/data/definitions/489.html).\n",
+                                    "markdown": "# Android debuggable attribute enabled\nThe Android manifest file defines configuration settings for Android applications. In this file, the `android:debuggable` attribute of the `application` element can be used to define whether or not the application can be debugged. When set to `true`, this attribute will allow the application to be debugged even when running on a device in user mode.\n\nWhen a debugger is enabled, it could allow for entry points in the application or reveal sensitive information. As a result, `android:debuggable` should only be enabled during development and should be disabled in production builds.\n\n\n## Recommendation\nIn Android applications, either set the `android:debuggable` attribute to `false`, or do not include it in the manifest. The default value, when not included, is `false`.\n\n\n## Example\nIn the example below, the `android:debuggable` attribute is set to `true`.\n\n\n```xml\n<manifest ... >\n    <!-- BAD: 'android:debuggable' set to 'true' -->\n    <application\n        android:debuggable=\"true\">\n        <activity ... >\n        </activity>\n    </application>\n</manifest>\n\n```\nThe corrected version sets the `android:debuggable` attribute to `false`.\n\n\n```xml\n<manifest ... >\n    <!-- GOOD: 'android:debuggable' set to 'false' -->\n    <application\n        android:debuggable=\"false\">\n        <activity ... >\n        </activity>\n    </application>\n</manifest>\n\n```\n\n## References\n* Android Developers: [App Manifest Overview](https://developer.android.com/guide/topics/manifest/manifest-intro).\n* Android Developers: [The android:debuggable attribute](https://developer.android.com/guide/topics/manifest/application-element#debug).\n* Android Developers: [Enable debugging](https://developer.android.com/studio/debug#enable-debug).\n* Common Weakness Enumeration: [CWE-489](https://cwe.mitre.org/data/definitions/489.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-489"
+                                    ],
+                                    "description": "An enabled debugger can allow for entry points in the application or reveal sensitive information.",
+                                    "id": "java/android/debuggable-attribute-enabled",
+                                    "kind": "problem",
+                                    "name": "Android debuggable attribute enabled",
+                                    "precision": "very-high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.2"
+                                }
+                            },
+                            {
+                                "id": "java/sql-injection",
+                                "name": "java/sql-injection",
+                                "shortDescription": {
+                                    "text": "Query built from user-controlled sources"
+                                },
+                                "fullDescription": {
+                                    "text": "Building a SQL or Java Persistence query from user-controlled sources is vulnerable to insertion of malicious code by the user."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Query built from user-controlled sources\nIf a database query is built using string concatenation, and the components of the concatenation include user input, a user is likely to be able to run malicious database queries. This applies to various database query languages, including SQL and the Java Persistence Query Language.\n\n\n## Recommendation\nUsually, it is better to use a SQL prepared statement than to build a complete SQL query with string concatenation. A prepared statement can include a wildcard, written as a question mark (?), for each part of the SQL query that is expected to be filled in by a different value each time it is run. When the query is later executed, a value must be supplied for each wildcard in the query.\n\nIn the Java Persistence Query Language, it is better to use queries with parameters than to build a complete query with string concatenation. A Java Persistence query can include a parameter placeholder for each part of the query that is expected to be filled in by a different value when run. A parameter placeholder may be indicated by a colon (:) followed by a parameter name, or by a question mark (?) followed by an integer position. When the query is later executed, a value must be supplied for each parameter in the query, using the `setParameter` method. Specifying the query using the `@NamedQuery` annotation introduces an additional level of safety: the query must be a constant string literal, preventing construction by string concatenation, and the only way to fill in values for parts of the query is by setting positional parameters.\n\nIt is good practice to use prepared statements (in SQL) or query parameters (in the Java Persistence Query Language) for supplying parameter values to a query, whether or not any of the parameters are directly traceable to user input. Doing so avoids any need to worry about quoting and escaping.\n\n\n## Example\nIn the following example, the code runs a simple SQL query in two different ways.\n\nThe first way involves building a query, `query1`, by concatenating an environment variable with some string literals. The environment variable can include special characters, so this code allows for SQL injection attacks.\n\nThe second way, which shows good practice, involves building a query, `query2`, with a single string literal that includes a wildcard (`?`). The wildcard is then given a value by calling `setString`. This version is immune to injection attacks, because any special characters in the environment variable are not given any special treatment.\n\n\n```java\n{\n    // BAD: the category might have SQL special characters in it\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Statement statement = connection.createStatement();\n    String query1 = \"SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='\"\n        + category + \"' ORDER BY PRICE\";\n    ResultSet results = statement.executeQuery(query1);\n}\n\n{\n    // GOOD: use a prepared query\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    String query2 = \"SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY=? ORDER BY PRICE\";\n    PreparedStatement statement = connection.prepareStatement(query2);\n    statement.setString(1, category);\n    ResultSet results = statement.executeQuery();\n}\n```\n\n## Example\nThe following code shows several different ways to run a Java Persistence query.\n\nThe first example involves building a query, `query1`, by concatenating an environment variable with some string literals. Just like the SQL example, the environment variable can include special characters, so this code allows for Java Persistence query injection attacks.\n\nThe remaining examples demonstrate different methods for safely building a Java Persistence query with user-supplied values:\n\n1. `query2` uses a single string literal that includes a placeholder for a parameter, indicated by a colon (`:`) and parameter name (`category`).\n1. `query3` uses a single string literal that includes a placeholder for a parameter, indicated by a question mark (`?`) and position number (`1`).\n1. `namedQuery1` is defined using the `@NamedQuery` annotation, whose `query` attribute is a string literal that includes a placeholder for a parameter, indicated by a colon (`:`) and parameter name (`category`).\n1. `namedQuery2` is defined using the `@NamedQuery` annotation, whose `query` attribute includes a placeholder for a parameter, indicated by a question mark (`?`) and position number (`1`).\nThe parameter is then given a value by calling `setParameter`. These versions are immune to injection attacks, because any special characters in the environment variable or user-supplied value are not given any special treatment.\n\n\n```java\n{\n    // BAD: the category might have Java Persistence Query Language special characters in it\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Statement statement = connection.createStatement();\n    String query1 = \"SELECT p FROM Product p WHERE p.category LIKE '\"\n        + category + \"' ORDER BY p.price\";\n    Query q = entityManager.createQuery(query1);\n}\n\n{\n    // GOOD: use a named parameter and set its value\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    String query2 = \"SELECT p FROM Product p WHERE p.category LIKE :category ORDER BY p.price\"\n    Query q = entityManager.createQuery(query2);\n    q.setParameter(\"category\", category);\n}\n\n{\n    // GOOD: use a positional parameter and set its value\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    String query3 = \"SELECT p FROM Product p WHERE p.category LIKE ?1 ORDER BY p.price\"\n    Query q = entityManager.createQuery(query3);\n    q.setParameter(1, category);\n}\n\n{\n    // GOOD: use a named query with a named parameter and set its value\n    @NamedQuery(\n            name=\"lookupByCategory\",\n            query=\"SELECT p FROM Product p WHERE p.category LIKE :category ORDER BY p.price\")\n    private static class NQ {}\n    ...\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Query namedQuery1 = entityManager.createNamedQuery(\"lookupByCategory\");\n    namedQuery1.setParameter(\"category\", category);\n}\n\n{\n    // GOOD: use a named query with a positional parameter and set its value\n    @NamedQuery(\n            name=\"lookupByCategory\",\n            query=\"SELECT p FROM Product p WHERE p.category LIKE ?1 ORDER BY p.price\")\n    private static class NQ {}\n    ...\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Query namedQuery2 = entityManager.createNamedQuery(\"lookupByCategory\");\n    namedQuery2.setParameter(1, category);\n}\n```\n\n## References\n* OWASP: [SQL Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html).\n* SEI CERT Oracle Coding Standard for Java: [IDS00-J. Prevent SQL injection](https://wiki.sei.cmu.edu/confluence/display/java/IDS00-J.+Prevent+SQL+injection).\n* The Java Tutorials: [Using Prepared Statements](https://docs.oracle.com/javase/tutorial/jdbc/basics/prepared.html).\n* The Java EE Tutorial: [The Java Persistence Query Language](https://docs.oracle.com/javaee/7/tutorial/persistence-querylanguage.htm).\n* Common Weakness Enumeration: [CWE-89](https://cwe.mitre.org/data/definitions/89.html).\n* Common Weakness Enumeration: [CWE-564](https://cwe.mitre.org/data/definitions/564.html).\n",
+                                    "markdown": "# Query built from user-controlled sources\nIf a database query is built using string concatenation, and the components of the concatenation include user input, a user is likely to be able to run malicious database queries. This applies to various database query languages, including SQL and the Java Persistence Query Language.\n\n\n## Recommendation\nUsually, it is better to use a SQL prepared statement than to build a complete SQL query with string concatenation. A prepared statement can include a wildcard, written as a question mark (?), for each part of the SQL query that is expected to be filled in by a different value each time it is run. When the query is later executed, a value must be supplied for each wildcard in the query.\n\nIn the Java Persistence Query Language, it is better to use queries with parameters than to build a complete query with string concatenation. A Java Persistence query can include a parameter placeholder for each part of the query that is expected to be filled in by a different value when run. A parameter placeholder may be indicated by a colon (:) followed by a parameter name, or by a question mark (?) followed by an integer position. When the query is later executed, a value must be supplied for each parameter in the query, using the `setParameter` method. Specifying the query using the `@NamedQuery` annotation introduces an additional level of safety: the query must be a constant string literal, preventing construction by string concatenation, and the only way to fill in values for parts of the query is by setting positional parameters.\n\nIt is good practice to use prepared statements (in SQL) or query parameters (in the Java Persistence Query Language) for supplying parameter values to a query, whether or not any of the parameters are directly traceable to user input. Doing so avoids any need to worry about quoting and escaping.\n\n\n## Example\nIn the following example, the code runs a simple SQL query in two different ways.\n\nThe first way involves building a query, `query1`, by concatenating an environment variable with some string literals. The environment variable can include special characters, so this code allows for SQL injection attacks.\n\nThe second way, which shows good practice, involves building a query, `query2`, with a single string literal that includes a wildcard (`?`). The wildcard is then given a value by calling `setString`. This version is immune to injection attacks, because any special characters in the environment variable are not given any special treatment.\n\n\n```java\n{\n    // BAD: the category might have SQL special characters in it\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Statement statement = connection.createStatement();\n    String query1 = \"SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='\"\n        + category + \"' ORDER BY PRICE\";\n    ResultSet results = statement.executeQuery(query1);\n}\n\n{\n    // GOOD: use a prepared query\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    String query2 = \"SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY=? ORDER BY PRICE\";\n    PreparedStatement statement = connection.prepareStatement(query2);\n    statement.setString(1, category);\n    ResultSet results = statement.executeQuery();\n}\n```\n\n## Example\nThe following code shows several different ways to run a Java Persistence query.\n\nThe first example involves building a query, `query1`, by concatenating an environment variable with some string literals. Just like the SQL example, the environment variable can include special characters, so this code allows for Java Persistence query injection attacks.\n\nThe remaining examples demonstrate different methods for safely building a Java Persistence query with user-supplied values:\n\n1. `query2` uses a single string literal that includes a placeholder for a parameter, indicated by a colon (`:`) and parameter name (`category`).\n1. `query3` uses a single string literal that includes a placeholder for a parameter, indicated by a question mark (`?`) and position number (`1`).\n1. `namedQuery1` is defined using the `@NamedQuery` annotation, whose `query` attribute is a string literal that includes a placeholder for a parameter, indicated by a colon (`:`) and parameter name (`category`).\n1. `namedQuery2` is defined using the `@NamedQuery` annotation, whose `query` attribute includes a placeholder for a parameter, indicated by a question mark (`?`) and position number (`1`).\nThe parameter is then given a value by calling `setParameter`. These versions are immune to injection attacks, because any special characters in the environment variable or user-supplied value are not given any special treatment.\n\n\n```java\n{\n    // BAD: the category might have Java Persistence Query Language special characters in it\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Statement statement = connection.createStatement();\n    String query1 = \"SELECT p FROM Product p WHERE p.category LIKE '\"\n        + category + \"' ORDER BY p.price\";\n    Query q = entityManager.createQuery(query1);\n}\n\n{\n    // GOOD: use a named parameter and set its value\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    String query2 = \"SELECT p FROM Product p WHERE p.category LIKE :category ORDER BY p.price\"\n    Query q = entityManager.createQuery(query2);\n    q.setParameter(\"category\", category);\n}\n\n{\n    // GOOD: use a positional parameter and set its value\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    String query3 = \"SELECT p FROM Product p WHERE p.category LIKE ?1 ORDER BY p.price\"\n    Query q = entityManager.createQuery(query3);\n    q.setParameter(1, category);\n}\n\n{\n    // GOOD: use a named query with a named parameter and set its value\n    @NamedQuery(\n            name=\"lookupByCategory\",\n            query=\"SELECT p FROM Product p WHERE p.category LIKE :category ORDER BY p.price\")\n    private static class NQ {}\n    ...\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Query namedQuery1 = entityManager.createNamedQuery(\"lookupByCategory\");\n    namedQuery1.setParameter(\"category\", category);\n}\n\n{\n    // GOOD: use a named query with a positional parameter and set its value\n    @NamedQuery(\n            name=\"lookupByCategory\",\n            query=\"SELECT p FROM Product p WHERE p.category LIKE ?1 ORDER BY p.price\")\n    private static class NQ {}\n    ...\n    String category = System.getenv(\"ITEM_CATEGORY\");\n    Query namedQuery2 = entityManager.createNamedQuery(\"lookupByCategory\");\n    namedQuery2.setParameter(1, category);\n}\n```\n\n## References\n* OWASP: [SQL Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html).\n* SEI CERT Oracle Coding Standard for Java: [IDS00-J. Prevent SQL injection](https://wiki.sei.cmu.edu/confluence/display/java/IDS00-J.+Prevent+SQL+injection).\n* The Java Tutorials: [Using Prepared Statements](https://docs.oracle.com/javase/tutorial/jdbc/basics/prepared.html).\n* The Java EE Tutorial: [The Java Persistence Query Language](https://docs.oracle.com/javaee/7/tutorial/persistence-querylanguage.htm).\n* Common Weakness Enumeration: [CWE-89](https://cwe.mitre.org/data/definitions/89.html).\n* Common Weakness Enumeration: [CWE-564](https://cwe.mitre.org/data/definitions/564.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-089",
+                                        "external/cwe/cwe-564"
+                                    ],
+                                    "description": "Building a SQL or Java Persistence query from user-controlled sources is vulnerable to insertion of\n              malicious code by the user.",
+                                    "id": "java/sql-injection",
+                                    "kind": "path-problem",
+                                    "name": "Query built from user-controlled sources",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "8.8"
+                                }
+                            },
+                            {
+                                "id": "java/tainted-format-string",
+                                "name": "java/tainted-format-string",
+                                "shortDescription": {
+                                    "text": "Use of externally-controlled format string"
+                                },
+                                "fullDescription": {
+                                    "text": "Using external input in format strings can lead to exceptions or information leaks."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Use of externally-controlled format string\nThe `String.format` method and related methods, like `PrintStream.printf` and `Formatter.format`, all accept a format string that is used to format the trailing arguments to the format call by providing inline format specifiers. If the format string contains unsanitized input from an untrusted source, then that string may contain extra format specifiers that cause an exception to be thrown or information to be leaked.\n\nThe Java standard library implementation for the format methods throws an exception if either the format specifier does not match the type of the argument, or if there are too few or too many arguments. If unsanitized input is used in the format string, it may contain invalid extra format specifiers which cause an exception to be thrown.\n\nPositional format specifiers may be used to access an argument to the format call by position. Unsanitized input in the format string may use a positional format specifier to access information that was not intended to be visible. For example, when formatting a Calendar instance we may intend to print only the year, but a user-specified format string may include a specifier to access the month and day.\n\n\n## Recommendation\nIf the argument passed as a format string is meant to be a plain string rather than a format string, then pass `%s` as the format string, and pass the original argument as the sole trailing argument.\n\n\n## Example\nThe following program is meant to check a card security code for a stored credit card:\n\n\n```java\npublic class ResponseSplitting extends HttpServlet {\n  protected void doGet(HttpServletRequest request, HttpServletResponse response)\n  throws ServletException, IOException {\n    Calendar expirationDate = new GregorianCalendar(2017, GregorianCalendar.SEPTEMBER, 1);\n    // User provided value\n    String cardSecurityCode = request.getParameter(\"cardSecurityCode\");\n    \n    if (notValid(cardSecurityCode)) {\n      \n      /*\n       * BAD: user provided value is included in the format string.\n       * A malicious user could provide an extra format specifier, which causes an\n       * exception to be thrown. Or they could provide a %1$tm or %1$te format specifier to\n       * access the month or day of the expiration date.\n       */\n      System.out.format(cardSecurityCode +\n                          \" is not the right value. Hint: the card expires in %1$ty.\",\n                        expirationDate);\n      \n      // GOOD: %s is used to include the user-provided cardSecurityCode in the output\n      System.out.format(\"%s is not the right value. Hint: the card expires in %2$ty.\",\n                        cardSecurityCode,\n                        expirationDate);\n    }\n\n  }\n}\n```\nHowever, in the first format call it uses the cardSecurityCode provided by the user in a format string. If the user includes a format specifier in the cardSecurityCode field, they may be able to cause an exception to be thrown, or to be able to access extra information about the stored card expiration date.\n\nThe second format call shows the correct approach. The user-provided value is passed as an argument to the format call. This prevents any format specifiers in the user provided value from being evaluated.\n\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [IDS06-J. Exclude unsanitized user input from format strings](https://wiki.sei.cmu.edu/confluence/display/java/IDS06-J.+Exclude+unsanitized+user+input+from+format+strings).\n* The Java Tutorials: [Formatting Numeric Print Output](https://docs.oracle.com/javase/tutorial/java/data/numberformat.html).\n* Java API Specification: [Formatter](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Formatter.html).\n* Common Weakness Enumeration: [CWE-134](https://cwe.mitre.org/data/definitions/134.html).\n",
+                                    "markdown": "# Use of externally-controlled format string\nThe `String.format` method and related methods, like `PrintStream.printf` and `Formatter.format`, all accept a format string that is used to format the trailing arguments to the format call by providing inline format specifiers. If the format string contains unsanitized input from an untrusted source, then that string may contain extra format specifiers that cause an exception to be thrown or information to be leaked.\n\nThe Java standard library implementation for the format methods throws an exception if either the format specifier does not match the type of the argument, or if there are too few or too many arguments. If unsanitized input is used in the format string, it may contain invalid extra format specifiers which cause an exception to be thrown.\n\nPositional format specifiers may be used to access an argument to the format call by position. Unsanitized input in the format string may use a positional format specifier to access information that was not intended to be visible. For example, when formatting a Calendar instance we may intend to print only the year, but a user-specified format string may include a specifier to access the month and day.\n\n\n## Recommendation\nIf the argument passed as a format string is meant to be a plain string rather than a format string, then pass `%s` as the format string, and pass the original argument as the sole trailing argument.\n\n\n## Example\nThe following program is meant to check a card security code for a stored credit card:\n\n\n```java\npublic class ResponseSplitting extends HttpServlet {\n  protected void doGet(HttpServletRequest request, HttpServletResponse response)\n  throws ServletException, IOException {\n    Calendar expirationDate = new GregorianCalendar(2017, GregorianCalendar.SEPTEMBER, 1);\n    // User provided value\n    String cardSecurityCode = request.getParameter(\"cardSecurityCode\");\n    \n    if (notValid(cardSecurityCode)) {\n      \n      /*\n       * BAD: user provided value is included in the format string.\n       * A malicious user could provide an extra format specifier, which causes an\n       * exception to be thrown. Or they could provide a %1$tm or %1$te format specifier to\n       * access the month or day of the expiration date.\n       */\n      System.out.format(cardSecurityCode +\n                          \" is not the right value. Hint: the card expires in %1$ty.\",\n                        expirationDate);\n      \n      // GOOD: %s is used to include the user-provided cardSecurityCode in the output\n      System.out.format(\"%s is not the right value. Hint: the card expires in %2$ty.\",\n                        cardSecurityCode,\n                        expirationDate);\n    }\n\n  }\n}\n```\nHowever, in the first format call it uses the cardSecurityCode provided by the user in a format string. If the user includes a format specifier in the cardSecurityCode field, they may be able to cause an exception to be thrown, or to be able to access extra information about the stored card expiration date.\n\nThe second format call shows the correct approach. The user-provided value is passed as an argument to the format call. This prevents any format specifiers in the user provided value from being evaluated.\n\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [IDS06-J. Exclude unsanitized user input from format strings](https://wiki.sei.cmu.edu/confluence/display/java/IDS06-J.+Exclude+unsanitized+user+input+from+format+strings).\n* The Java Tutorials: [Formatting Numeric Print Output](https://docs.oracle.com/javase/tutorial/java/data/numberformat.html).\n* Java API Specification: [Formatter](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Formatter.html).\n* Common Weakness Enumeration: [CWE-134](https://cwe.mitre.org/data/definitions/134.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-134"
+                                    ],
+                                    "description": "Using external input in format strings can lead to exceptions or information leaks.",
+                                    "id": "java/tainted-format-string",
+                                    "kind": "path-problem",
+                                    "name": "Use of externally-controlled format string",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/ognl-injection",
+                                "name": "java/ognl-injection",
+                                "shortDescription": {
+                                    "text": "OGNL Expression Language statement with user-controlled input"
+                                },
+                                "fullDescription": {
+                                    "text": "Evaluation of OGNL Expression Language statement with user-controlled input can lead to execution of arbitrary code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# OGNL Expression Language statement with user-controlled input\nObject-Graph Navigation Language (OGNL) is an open-source Expression Language (EL) for Java. OGNL can create or change executable code, consequently it can introduce critical security flaws to any application that uses it. Evaluation of unvalidated expressions is a common flaw in OGNL. This exposes the properties of Java objects to modification by an attacker and may allow them to execute arbitrary code.\n\n\n## Recommendation\nThe general recommendation is to avoid evaluating untrusted ONGL expressions. If user-provided OGNL expressions must be evaluated, do this in a sandbox and validate the expressions before evaluation.\n\n\n## Example\nIn the following examples, the code accepts an OGNL expression from the user and evaluates it.\n\nIn the first example, the user-provided OGNL expression is parsed and evaluated.\n\nThe second example validates the expression and evaluates it inside a sandbox. You can add a sandbox by setting a system property, as shown in the example, or by adding `-Dognl.security.manager` to JVM arguments.\n\n\n```java\nimport ognl.Ognl;\nimport ognl.OgnlException;\n\npublic void evaluate(HttpServletRequest request, Object root) throws OgnlException {\n  String expression = request.getParameter(\"expression\");\n\n  // BAD: User provided expression is evaluated\n  Ognl.getValue(expression, root);\n  \n  // GOOD: The name is validated and expression is evaluated in sandbox\n  System.setProperty(\"ognl.security.manager\", \"\"); // Or add -Dognl.security.manager to JVM args\n  if (isValid(expression)) {\n    Ognl.getValue(expression, root);\n  } else {\n    // Reject the request\n  }\n}\n\npublic void isValid(Strig expression) {\n  // Custom method to validate the expression.\n  // For instance, make sure it doesn't include unexpected code.\n}\n\n```\n\n## References\n* Apache Commons: [Apache Commons OGNL](https://commons.apache.org/proper/commons-ognl/).\n* Struts security: [Proactively protect from OGNL Expression Injections attacks](https://struts.apache.org/security/#proactively-protect-from-ognl-expression-injections-attacks-if-easily-applicable).\n* Common Weakness Enumeration: [CWE-917](https://cwe.mitre.org/data/definitions/917.html).\n",
+                                    "markdown": "# OGNL Expression Language statement with user-controlled input\nObject-Graph Navigation Language (OGNL) is an open-source Expression Language (EL) for Java. OGNL can create or change executable code, consequently it can introduce critical security flaws to any application that uses it. Evaluation of unvalidated expressions is a common flaw in OGNL. This exposes the properties of Java objects to modification by an attacker and may allow them to execute arbitrary code.\n\n\n## Recommendation\nThe general recommendation is to avoid evaluating untrusted ONGL expressions. If user-provided OGNL expressions must be evaluated, do this in a sandbox and validate the expressions before evaluation.\n\n\n## Example\nIn the following examples, the code accepts an OGNL expression from the user and evaluates it.\n\nIn the first example, the user-provided OGNL expression is parsed and evaluated.\n\nThe second example validates the expression and evaluates it inside a sandbox. You can add a sandbox by setting a system property, as shown in the example, or by adding `-Dognl.security.manager` to JVM arguments.\n\n\n```java\nimport ognl.Ognl;\nimport ognl.OgnlException;\n\npublic void evaluate(HttpServletRequest request, Object root) throws OgnlException {\n  String expression = request.getParameter(\"expression\");\n\n  // BAD: User provided expression is evaluated\n  Ognl.getValue(expression, root);\n  \n  // GOOD: The name is validated and expression is evaluated in sandbox\n  System.setProperty(\"ognl.security.manager\", \"\"); // Or add -Dognl.security.manager to JVM args\n  if (isValid(expression)) {\n    Ognl.getValue(expression, root);\n  } else {\n    // Reject the request\n  }\n}\n\npublic void isValid(Strig expression) {\n  // Custom method to validate the expression.\n  // For instance, make sure it doesn't include unexpected code.\n}\n\n```\n\n## References\n* Apache Commons: [Apache Commons OGNL](https://commons.apache.org/proper/commons-ognl/).\n* Struts security: [Proactively protect from OGNL Expression Injections attacks](https://struts.apache.org/security/#proactively-protect-from-ognl-expression-injections-attacks-if-easily-applicable).\n* Common Weakness Enumeration: [CWE-917](https://cwe.mitre.org/data/definitions/917.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-917"
+                                    ],
+                                    "description": "Evaluation of OGNL Expression Language statement with user-controlled input can\n                lead to execution of arbitrary code.",
+                                    "id": "java/ognl-injection",
+                                    "kind": "path-problem",
+                                    "name": "OGNL Expression Language statement with user-controlled input",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.8"
+                                }
+                            },
+                            {
+                                "id": "java/stack-trace-exposure",
+                                "name": "java/stack-trace-exposure",
+                                "shortDescription": {
+                                    "text": "Information exposure through a stack trace"
+                                },
+                                "fullDescription": {
+                                    "text": "Information from a stack trace propagates to an external user. Stack traces can unintentionally reveal implementation details that are useful to an attacker for developing a subsequent exploit."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Information exposure through a stack trace\nSoftware developers often add stack traces to error messages, as a debugging aid. Whenever that error message occurs for an end user, the developer can use the stack trace to help identify how to fix the problem. In particular, stack traces can tell the developer more about the sequence of events that led to a failure, as opposed to merely the final state of the software when the error occurred.\n\nUnfortunately, the same information can be useful to an attacker. The sequence of class names in a stack trace can reveal the structure of the application as well as any internal components it relies on. Furthermore, the error message at the top of a stack trace can include information such as server-side file names and SQL code that the application relies on, allowing an attacker to fine-tune a subsequent injection attack.\n\n\n## Recommendation\nSend the user a more generic error message that reveals less information. Either suppress the stack trace entirely, or log it only on the server.\n\n\n## Example\nIn the following example, an exception is handled in two different ways. In the first version, labeled BAD, the exception is sent back to the remote user using the `sendError()` method. As such, the user is able to see a detailed stack trace, which may contain sensitive information. In the second version, the error message is logged only on the server. That way, the developers can still access and use the error log, but remote users will not see the information.\n\n\n```java\nprotected void doGet(HttpServletRequest request, HttpServletResponse response) {\n\ttry {\n\t\tdoSomeWork();\n\t} catch (NullPointerException ex) {\n\t\t// BAD: printing a stack trace back to the response\n\t\tex.printStackTrace(response.getWriter());\n\t\treturn;\n\t}\n\n\ttry {\n\t\tdoSomeWork();\n\t} catch (NullPointerException ex) {\n\t\t// GOOD: log the stack trace, and send back a non-revealing response\n\t\tlog(\"Exception occurred\", ex);\n\t\tresponse.sendError(\n\t\t\tHttpServletResponse.SC_INTERNAL_SERVER_ERROR,\n\t\t\t\"Exception occurred\");\n\t\treturn;\n\t}\n}\n\n```\n\n## References\n* OWASP: [Improper Error Handling](https://owasp.org/www-community/Improper_Error_Handling).\n* CERT Java Coding Standard: [ERR01-J. Do not allow exceptions to expose sensitive information](https://www.securecoding.cert.org/confluence/display/java/ERR01-J.+Do+not+allow+exceptions+to+expose+sensitive+information).\n* Common Weakness Enumeration: [CWE-209](https://cwe.mitre.org/data/definitions/209.html).\n* Common Weakness Enumeration: [CWE-497](https://cwe.mitre.org/data/definitions/497.html).\n",
+                                    "markdown": "# Information exposure through a stack trace\nSoftware developers often add stack traces to error messages, as a debugging aid. Whenever that error message occurs for an end user, the developer can use the stack trace to help identify how to fix the problem. In particular, stack traces can tell the developer more about the sequence of events that led to a failure, as opposed to merely the final state of the software when the error occurred.\n\nUnfortunately, the same information can be useful to an attacker. The sequence of class names in a stack trace can reveal the structure of the application as well as any internal components it relies on. Furthermore, the error message at the top of a stack trace can include information such as server-side file names and SQL code that the application relies on, allowing an attacker to fine-tune a subsequent injection attack.\n\n\n## Recommendation\nSend the user a more generic error message that reveals less information. Either suppress the stack trace entirely, or log it only on the server.\n\n\n## Example\nIn the following example, an exception is handled in two different ways. In the first version, labeled BAD, the exception is sent back to the remote user using the `sendError()` method. As such, the user is able to see a detailed stack trace, which may contain sensitive information. In the second version, the error message is logged only on the server. That way, the developers can still access and use the error log, but remote users will not see the information.\n\n\n```java\nprotected void doGet(HttpServletRequest request, HttpServletResponse response) {\n\ttry {\n\t\tdoSomeWork();\n\t} catch (NullPointerException ex) {\n\t\t// BAD: printing a stack trace back to the response\n\t\tex.printStackTrace(response.getWriter());\n\t\treturn;\n\t}\n\n\ttry {\n\t\tdoSomeWork();\n\t} catch (NullPointerException ex) {\n\t\t// GOOD: log the stack trace, and send back a non-revealing response\n\t\tlog(\"Exception occurred\", ex);\n\t\tresponse.sendError(\n\t\t\tHttpServletResponse.SC_INTERNAL_SERVER_ERROR,\n\t\t\t\"Exception occurred\");\n\t\treturn;\n\t}\n}\n\n```\n\n## References\n* OWASP: [Improper Error Handling](https://owasp.org/www-community/Improper_Error_Handling).\n* CERT Java Coding Standard: [ERR01-J. Do not allow exceptions to expose sensitive information](https://www.securecoding.cert.org/confluence/display/java/ERR01-J.+Do+not+allow+exceptions+to+expose+sensitive+information).\n* Common Weakness Enumeration: [CWE-209](https://cwe.mitre.org/data/definitions/209.html).\n* Common Weakness Enumeration: [CWE-497](https://cwe.mitre.org/data/definitions/497.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-209",
+                                        "external/cwe/cwe-497"
+                                    ],
+                                    "description": "Information from a stack trace propagates to an external user.\n              Stack traces can unintentionally reveal implementation details\n              that are useful to an attacker for developing a subsequent exploit.",
+                                    "id": "java/stack-trace-exposure",
+                                    "kind": "problem",
+                                    "name": "Information exposure through a stack trace",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "5.4"
+                                }
+                            },
+                            {
+                                "id": "java/partial-path-traversal-from-remote",
+                                "name": "java/partial-path-traversal-from-remote",
+                                "shortDescription": {
+                                    "text": "Partial path traversal vulnerability from remote"
+                                },
+                                "fullDescription": {
+                                    "text": "A prefix used to check that a canonicalised path falls within another must be slash-terminated."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Partial path traversal vulnerability from remote\nA common way to check that a user-supplied path `SUBDIR` falls inside a directory `DIR` is to use `getCanonicalPath()` to remove any path-traversal elements and then check that `DIR` is a prefix. However, if `DIR` is not slash-terminated, this can unexpectedly allow accessing siblings of `DIR`.\n\nSee also `java/partial-path-traversal`, which is similar to this query, but may also flag non-remotely-exploitable instances of partial path traversal vulnerabilities.\n\n\n## Recommendation\nIf the user should only access items within a certain directory `DIR`, ensure that `DIR` is slash-terminated before checking that `DIR` is a prefix of the user-provided path, `SUBDIR`. Note, Java's `getCanonicalPath()` returns a **non**-slash-terminated path string, so a slash must be added to `DIR` if that method is used.\n\n\n## Example\nIn this example, the `if` statement checks if `parent.getCanonicalPath()` is a prefix of `dir.getCanonicalPath()`. However, `parent.getCanonicalPath()` is not slash-terminated. This means that users that supply `dir` may be also allowed to access siblings of `parent` and not just children of `parent`, which is a security issue.\n\n\n```java\npublic class PartialPathTraversalBad {\n    public void example(File dir, File parent) throws IOException {\n        if (!dir.getCanonicalPath().startsWith(parent.getCanonicalPath())) {\n            throw new IOException(\"Invalid directory: \" + dir.getCanonicalPath());\n        }\n    }\n}\n\n```\nIn this example, the `if` statement checks if `parent.getCanonicalPath() + File.separator ` is a prefix of `dir.getCanonicalPath()`. Because `parent.getCanonicalPath() + File.separator` is indeed slash-terminated, the user supplying `dir` can only access children of `parent`, as desired.\n\n\n```java\npublic class PartialPathTraversalGood {\n    public void example(File dir, File parent) throws IOException {\n        if (!dir.getCanonicalPath().startsWith(parent.getCanonicalPath() + File.separator)) {\n            throw new IOException(\"Invalid directory: \" + dir.getCanonicalPath());\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Partial Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).\n* CVE-2022-23457: [ ESAPI Vulnerability Report](https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/GHSL-2022-008_The_OWASP_Enterprise_Security_API.md).\n* Common Weakness Enumeration: [CWE-23](https://cwe.mitre.org/data/definitions/23.html).\n",
+                                    "markdown": "# Partial path traversal vulnerability from remote\nA common way to check that a user-supplied path `SUBDIR` falls inside a directory `DIR` is to use `getCanonicalPath()` to remove any path-traversal elements and then check that `DIR` is a prefix. However, if `DIR` is not slash-terminated, this can unexpectedly allow accessing siblings of `DIR`.\n\nSee also `java/partial-path-traversal`, which is similar to this query, but may also flag non-remotely-exploitable instances of partial path traversal vulnerabilities.\n\n\n## Recommendation\nIf the user should only access items within a certain directory `DIR`, ensure that `DIR` is slash-terminated before checking that `DIR` is a prefix of the user-provided path, `SUBDIR`. Note, Java's `getCanonicalPath()` returns a **non**-slash-terminated path string, so a slash must be added to `DIR` if that method is used.\n\n\n## Example\nIn this example, the `if` statement checks if `parent.getCanonicalPath()` is a prefix of `dir.getCanonicalPath()`. However, `parent.getCanonicalPath()` is not slash-terminated. This means that users that supply `dir` may be also allowed to access siblings of `parent` and not just children of `parent`, which is a security issue.\n\n\n```java\npublic class PartialPathTraversalBad {\n    public void example(File dir, File parent) throws IOException {\n        if (!dir.getCanonicalPath().startsWith(parent.getCanonicalPath())) {\n            throw new IOException(\"Invalid directory: \" + dir.getCanonicalPath());\n        }\n    }\n}\n\n```\nIn this example, the `if` statement checks if `parent.getCanonicalPath() + File.separator ` is a prefix of `dir.getCanonicalPath()`. Because `parent.getCanonicalPath() + File.separator` is indeed slash-terminated, the user supplying `dir` can only access children of `parent`, as desired.\n\n\n```java\npublic class PartialPathTraversalGood {\n    public void example(File dir, File parent) throws IOException {\n        if (!dir.getCanonicalPath().startsWith(parent.getCanonicalPath() + File.separator)) {\n            throw new IOException(\"Invalid directory: \" + dir.getCanonicalPath());\n        }\n    }\n}\n\n```\n\n## References\n* OWASP: [Partial Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).\n* CVE-2022-23457: [ ESAPI Vulnerability Report](https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/GHSL-2022-008_The_OWASP_Enterprise_Security_API.md).\n* Common Weakness Enumeration: [CWE-23](https://cwe.mitre.org/data/definitions/23.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-023"
+                                    ],
+                                    "description": "A prefix used to check that a canonicalised path falls within another must be slash-terminated.",
+                                    "id": "java/partial-path-traversal-from-remote",
+                                    "kind": "path-problem",
+                                    "name": "Partial path traversal vulnerability from remote",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.3"
+                                }
+                            },
+                            {
+                                "id": "java/tainted-numeric-cast",
+                                "name": "java/tainted-numeric-cast",
+                                "shortDescription": {
+                                    "text": "User-controlled data in numeric cast"
+                                },
+                                "fullDescription": {
+                                    "text": "Casting user-controlled numeric data to a narrower type without validation can cause unexpected truncation."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# User-controlled data in numeric cast\nCasting a user-controlled numeric value to a narrower type can result in truncated values unless the input is validated.\n\nNarrowing conversions may cause potentially unintended results. For example, casting the positive integer value `128` to type `byte` yields the negative value `-128`.\n\n\n## Recommendation\nGuard against unexpected truncation of user-controlled arithmetic data by doing one of the following:\n\n* Validate the user input.\n* Define a guard on the cast expression, so that the cast is performed only if the input is known to be within the range of the resulting type.\n* Avoid casting to a narrower type, and instead continue to use a wider type.\n\n## Example\nIn this example, a value is read from standard input into a `long`. Because the value is a user-controlled value, it could be extremely large. Casting this value to a narrower type could therefore cause unexpected truncation. The `scaled2` example uses a guard to avoid this problem and checks the range of the input before performing the cast. If the value is too large to cast to type `int` it is rejected as invalid.\n\n\n```java\nclass Test {\n\tpublic static void main(String[] args) throws IOException {\n\t\t{\n\t\t\tlong data;\n\n\t\t\tBufferedReader readerBuffered = new BufferedReader(\n\t\t\t\t\tnew InputStreamReader(System.in, \"UTF-8\"));\n\t\t\tString stringNumber = readerBuffered.readLine();\n\t\t\tif (stringNumber != null) {\n\t\t\t\tdata = Long.parseLong(stringNumber.trim());\n\t\t\t} else {\n\t\t\t\tdata = 0;\n\t\t\t}\n\n\t\t\t// AVOID: potential truncation if input data is very large,\n\t\t\t// for example 'Long.MAX_VALUE'\n\t\t\tint scaled = (int)data;\n\n\t\t\t//...\n\n\t\t\t// GOOD: use a guard to ensure no truncation occurs\n\t\t\tint scaled2;\n\t\t\tif (data > Integer.MIN_VALUE && data < Integer.MAX_VALUE)\n\t\t\t\tscaled2 = (int)data;\n\t\t\telse\n\t\t\t\tthrow new IllegalArgumentException(\"Invalid input\");\n\t\t}\n\t}\n}\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [NUM12-J. Ensure conversions of numeric types to narrower types do not result in lost or misinterpreted data](https://wiki.sei.cmu.edu/confluence/display/java/NUM12-J.+Ensure+conversions+of+numeric+types+to+narrower+types+do+not+result+in+lost+or+misinterpreted+data).\n* Common Weakness Enumeration: [CWE-197](https://cwe.mitre.org/data/definitions/197.html).\n* Common Weakness Enumeration: [CWE-681](https://cwe.mitre.org/data/definitions/681.html).\n",
+                                    "markdown": "# User-controlled data in numeric cast\nCasting a user-controlled numeric value to a narrower type can result in truncated values unless the input is validated.\n\nNarrowing conversions may cause potentially unintended results. For example, casting the positive integer value `128` to type `byte` yields the negative value `-128`.\n\n\n## Recommendation\nGuard against unexpected truncation of user-controlled arithmetic data by doing one of the following:\n\n* Validate the user input.\n* Define a guard on the cast expression, so that the cast is performed only if the input is known to be within the range of the resulting type.\n* Avoid casting to a narrower type, and instead continue to use a wider type.\n\n## Example\nIn this example, a value is read from standard input into a `long`. Because the value is a user-controlled value, it could be extremely large. Casting this value to a narrower type could therefore cause unexpected truncation. The `scaled2` example uses a guard to avoid this problem and checks the range of the input before performing the cast. If the value is too large to cast to type `int` it is rejected as invalid.\n\n\n```java\nclass Test {\n\tpublic static void main(String[] args) throws IOException {\n\t\t{\n\t\t\tlong data;\n\n\t\t\tBufferedReader readerBuffered = new BufferedReader(\n\t\t\t\t\tnew InputStreamReader(System.in, \"UTF-8\"));\n\t\t\tString stringNumber = readerBuffered.readLine();\n\t\t\tif (stringNumber != null) {\n\t\t\t\tdata = Long.parseLong(stringNumber.trim());\n\t\t\t} else {\n\t\t\t\tdata = 0;\n\t\t\t}\n\n\t\t\t// AVOID: potential truncation if input data is very large,\n\t\t\t// for example 'Long.MAX_VALUE'\n\t\t\tint scaled = (int)data;\n\n\t\t\t//...\n\n\t\t\t// GOOD: use a guard to ensure no truncation occurs\n\t\t\tint scaled2;\n\t\t\tif (data > Integer.MIN_VALUE && data < Integer.MAX_VALUE)\n\t\t\t\tscaled2 = (int)data;\n\t\t\telse\n\t\t\t\tthrow new IllegalArgumentException(\"Invalid input\");\n\t\t}\n\t}\n}\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [NUM12-J. Ensure conversions of numeric types to narrower types do not result in lost or misinterpreted data](https://wiki.sei.cmu.edu/confluence/display/java/NUM12-J.+Ensure+conversions+of+numeric+types+to+narrower+types+do+not+result+in+lost+or+misinterpreted+data).\n* Common Weakness Enumeration: [CWE-197](https://cwe.mitre.org/data/definitions/197.html).\n* Common Weakness Enumeration: [CWE-681](https://cwe.mitre.org/data/definitions/681.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-197",
+                                        "external/cwe/cwe-681"
+                                    ],
+                                    "description": "Casting user-controlled numeric data to a narrower type without validation\n              can cause unexpected truncation.",
+                                    "id": "java/tainted-numeric-cast",
+                                    "kind": "path-problem",
+                                    "name": "User-controlled data in numeric cast",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.0"
+                                }
+                            },
+                            {
+                                "id": "java/ssrf",
+                                "name": "java/ssrf",
+                                "shortDescription": {
+                                    "text": "Server-side request forgery"
+                                },
+                                "fullDescription": {
+                                    "text": "Making web requests based on unvalidated user-input may cause the server to communicate with malicious servers."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Server-side request forgery\nDirectly incorporating user input into an HTTP request without validating the input can facilitate server-side request forgery (SSRF) attacks. In these attacks, the server may be tricked into making a request and interacting with an attacker-controlled server.\n\n\n## Recommendation\nTo guard against SSRF attacks, you should avoid putting user-provided input directly into a request URL. Instead, maintain a list of authorized URLs on the server; then choose from that list based on the input provided. Alternatively, ensure requests constructed from user input are limited to a particular host or more restrictive URL prefix.\n\n\n## Example\nThe following example shows an HTTP request parameter being used directly to form a new request without validating the input, which facilitates SSRF attacks. It also shows how to remedy the problem by validating the user input against a known fixed string.\n\n\n```java\nimport java.net.http.HttpClient;\n\npublic class SSRF extends HttpServlet {\n\tprivate static final String VALID_URI = \"http://lgtm.com\";\n\tprivate HttpClient client = HttpClient.newHttpClient();\n\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\t\tthrows ServletException, IOException {\n\t\tURI uri = new URI(request.getParameter(\"uri\"));\n\t\t// BAD: a request parameter is incorporated without validation into a Http request\n\t\tHttpRequest r = HttpRequest.newBuilder(uri).build();\n\t\tclient.send(r, null);\n\n\t\t// GOOD: the request parameter is validated against a known fixed string\n\t\tif (VALID_URI.equals(request.getParameter(\"uri\"))) {\n\t\t\tHttpRequest r2 = HttpRequest.newBuilder(uri).build();\n\t\t\tclient.send(r2, null);\n\t\t}\n\t}\n}\n\n```\n\n## References\n* [OWASP SSRF](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery)\n* Common Weakness Enumeration: [CWE-918](https://cwe.mitre.org/data/definitions/918.html).\n",
+                                    "markdown": "# Server-side request forgery\nDirectly incorporating user input into an HTTP request without validating the input can facilitate server-side request forgery (SSRF) attacks. In these attacks, the server may be tricked into making a request and interacting with an attacker-controlled server.\n\n\n## Recommendation\nTo guard against SSRF attacks, you should avoid putting user-provided input directly into a request URL. Instead, maintain a list of authorized URLs on the server; then choose from that list based on the input provided. Alternatively, ensure requests constructed from user input are limited to a particular host or more restrictive URL prefix.\n\n\n## Example\nThe following example shows an HTTP request parameter being used directly to form a new request without validating the input, which facilitates SSRF attacks. It also shows how to remedy the problem by validating the user input against a known fixed string.\n\n\n```java\nimport java.net.http.HttpClient;\n\npublic class SSRF extends HttpServlet {\n\tprivate static final String VALID_URI = \"http://lgtm.com\";\n\tprivate HttpClient client = HttpClient.newHttpClient();\n\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\t\tthrows ServletException, IOException {\n\t\tURI uri = new URI(request.getParameter(\"uri\"));\n\t\t// BAD: a request parameter is incorporated without validation into a Http request\n\t\tHttpRequest r = HttpRequest.newBuilder(uri).build();\n\t\tclient.send(r, null);\n\n\t\t// GOOD: the request parameter is validated against a known fixed string\n\t\tif (VALID_URI.equals(request.getParameter(\"uri\"))) {\n\t\t\tHttpRequest r2 = HttpRequest.newBuilder(uri).build();\n\t\t\tclient.send(r2, null);\n\t\t}\n\t}\n}\n\n```\n\n## References\n* [OWASP SSRF](https://owasp.org/www-community/attacks/Server_Side_Request_Forgery)\n* Common Weakness Enumeration: [CWE-918](https://cwe.mitre.org/data/definitions/918.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-918"
+                                    ],
+                                    "description": "Making web requests based on unvalidated user-input\n              may cause the server to communicate with malicious servers.",
+                                    "id": "java/ssrf",
+                                    "kind": "path-problem",
+                                    "name": "Server-side request forgery",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "9.1"
+                                }
+                            },
+                            {
+                                "id": "java/android/intent-uri-permission-manipulation",
+                                "name": "java/android/intent-uri-permission-manipulation",
+                                "shortDescription": {
+                                    "text": "Intent URI permission manipulation"
+                                },
+                                "fullDescription": {
+                                    "text": "Returning an externally provided Intent via 'setResult' may allow a malicious application to access arbitrary content providers of the vulnerable application."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Intent URI permission manipulation\nWhen an Android component expects a result from an Activity, `startActivityForResult` can be used. The started Activity can then use `setResult` to return the appropriate data to the calling component.\n\nIf an Activity obtains the incoming, user-provided Intent and directly returns it via `setResult` without any checks, the application may be unintentionally giving arbitrary access to its content providers, even if they are not exported, as long as they are configured with the attribute `android:grantUriPermissions=\"true\"`. This happens because the attacker adds the appropriate URI permission flags to the provided Intent, which take effect once the Intent is reflected back.\n\n\n## Recommendation\nAvoid returning user-provided or untrusted Intents via `setResult`. Use a new Intent instead.\n\nIf it is required to use the received Intent, make sure that it does not contain URI permission flags, either by checking them with `Intent.getFlags` or removing them with `Intent.removeFlags`.\n\n\n## Example\nThe following sample contains three examples. In the first example, a user-provided Intent is obtained and directly returned back with `setResult`, which is dangerous. In the second example, a new Intent is created to safely return the desired data. The third example shows how the obtained Intent can be sanitized by removing dangerous flags before using it to return data to the calling component.\n\n\n```java\npublic class IntentUriPermissionManipulation extends Activity {\n\n    // BAD: the user-provided Intent is returned as-is\n    public void dangerous() {\n        Intent intent = getIntent();\n        intent.putExtra(\"result\", \"resultData\");\n        setResult(intent);\n    }\n\n    // GOOD: a new Intent is created and returned\n    public void safe() {\n        Intent intent = new Intent();\n        intent.putExtra(\"result\", \"resultData\");\n        setResult(intent);\n    }\n\n    // GOOD: the user-provided Intent is sanitized before being returned\n    public void sanitized() {\n        Intent intent = getIntent();\n        intent.putExtra(\"result\", \"resultData\");\n        intent.removeFlags(\n                Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);\n        setResult(intent);\n    }\n}\n\n```\n\n## References\n* Google Help: [Remediation for Intent Redirection Vulnerability](https://support.google.com/faqs/answer/9267555?hl=en).\n* Common Weakness Enumeration: [CWE-266](https://cwe.mitre.org/data/definitions/266.html).\n* Common Weakness Enumeration: [CWE-926](https://cwe.mitre.org/data/definitions/926.html).\n",
+                                    "markdown": "# Intent URI permission manipulation\nWhen an Android component expects a result from an Activity, `startActivityForResult` can be used. The started Activity can then use `setResult` to return the appropriate data to the calling component.\n\nIf an Activity obtains the incoming, user-provided Intent and directly returns it via `setResult` without any checks, the application may be unintentionally giving arbitrary access to its content providers, even if they are not exported, as long as they are configured with the attribute `android:grantUriPermissions=\"true\"`. This happens because the attacker adds the appropriate URI permission flags to the provided Intent, which take effect once the Intent is reflected back.\n\n\n## Recommendation\nAvoid returning user-provided or untrusted Intents via `setResult`. Use a new Intent instead.\n\nIf it is required to use the received Intent, make sure that it does not contain URI permission flags, either by checking them with `Intent.getFlags` or removing them with `Intent.removeFlags`.\n\n\n## Example\nThe following sample contains three examples. In the first example, a user-provided Intent is obtained and directly returned back with `setResult`, which is dangerous. In the second example, a new Intent is created to safely return the desired data. The third example shows how the obtained Intent can be sanitized by removing dangerous flags before using it to return data to the calling component.\n\n\n```java\npublic class IntentUriPermissionManipulation extends Activity {\n\n    // BAD: the user-provided Intent is returned as-is\n    public void dangerous() {\n        Intent intent = getIntent();\n        intent.putExtra(\"result\", \"resultData\");\n        setResult(intent);\n    }\n\n    // GOOD: a new Intent is created and returned\n    public void safe() {\n        Intent intent = new Intent();\n        intent.putExtra(\"result\", \"resultData\");\n        setResult(intent);\n    }\n\n    // GOOD: the user-provided Intent is sanitized before being returned\n    public void sanitized() {\n        Intent intent = getIntent();\n        intent.putExtra(\"result\", \"resultData\");\n        intent.removeFlags(\n                Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);\n        setResult(intent);\n    }\n}\n\n```\n\n## References\n* Google Help: [Remediation for Intent Redirection Vulnerability](https://support.google.com/faqs/answer/9267555?hl=en).\n* Common Weakness Enumeration: [CWE-266](https://cwe.mitre.org/data/definitions/266.html).\n* Common Weakness Enumeration: [CWE-926](https://cwe.mitre.org/data/definitions/926.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-266",
+                                        "external/cwe/cwe-926"
+                                    ],
+                                    "description": "Returning an externally provided Intent via 'setResult' may allow a malicious\n              application to access arbitrary content providers of the vulnerable application.",
+                                    "id": "java/android/intent-uri-permission-manipulation",
+                                    "kind": "path-problem",
+                                    "name": "Intent URI permission manipulation",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.8"
+                                }
+                            },
+                            {
+                                "id": "java/missing-jwt-signature-check",
+                                "name": "java/missing-jwt-signature-check",
+                                "shortDescription": {
+                                    "text": "Missing JWT signature check"
+                                },
+                                "fullDescription": {
+                                    "text": "Failing to check the Json Web Token (JWT) signature may allow an attacker to forge their own tokens."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Missing JWT signature check\nA JSON Web Token (JWT) consists of three parts: header, payload, and signature. The `io.jsonwebtoken.jjwt` library is one of many libraries used for working with JWTs. It offers different methods for parsing tokens like `parse`, `parseClaimsJws`, and `parsePlaintextJws`. The last two correctly verify that the JWT is properly signed. This is done by computing the signature of the combination of header and payload and comparing the locally computed signature with the signature part of the JWT.\n\nTherefore it is necessary to provide the `JwtParser` with a key that is used for signature validation. Unfortunately the `parse` method **accepts** a JWT whose signature is empty although a signing key has been set for the parser. This means that an attacker can create arbitrary JWTs that will be accepted if this method is used.\n\n\n## Recommendation\nAlways verify the signature by using either the `parseClaimsJws` and `parsePlaintextJws` methods or by overriding the `onPlaintextJws` or `onClaimsJws` of `JwtHandlerAdapter`.\n\n\n## Example\nThe following example shows four cases where a signing key is set for a parser. In the first 'BAD' case the `parse` method is used, which will not validate the signature. The second 'BAD' case uses a `JwtHandlerAdapter` where the `onPlaintextJwt` method is overriden, so it will not validate the signature. The third and fourth 'GOOD' cases use `parseClaimsJws` method or override the `onPlaintextJws` method.\n\n\n```java\npublic void badJwt(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parse(token); // BAD: Does not verify the signature\n}\n\npublic void badJwtHandler(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parse(plaintextJwt, new JwtHandlerAdapter<Jwt<Header, String>>() {\n                    @Override\n                    public Jwt<Header, String> onPlaintextJwt(Jwt<Header, String> jwt) {\n                        return jwt;\n                    }\n                }); // BAD: The handler is called on an unverified JWT\n}\n\npublic void goodJwt(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parseClaimsJws(token) // GOOD: Verify the signature\n                .getBody();\n}\n\npublic void goodJwtHandler(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parse(plaintextJwt, new JwtHandlerAdapter<Jws<String>>() {\n                    @Override\n                    public Jws<String> onPlaintextJws(Jws<String> jws) {\n                        return jws;\n                    }\n                }); // GOOD: The handler is called on a verified JWS\n}\n```\n\n## References\n* zofrex: [How I Found An alg=none JWT Vulnerability in the NHS Contact Tracing App](https://www.zofrex.com/blog/2020/10/20/alg-none-jwt-nhs-contact-tracing-app/).\n* Common Weakness Enumeration: [CWE-347](https://cwe.mitre.org/data/definitions/347.html).\n",
+                                    "markdown": "# Missing JWT signature check\nA JSON Web Token (JWT) consists of three parts: header, payload, and signature. The `io.jsonwebtoken.jjwt` library is one of many libraries used for working with JWTs. It offers different methods for parsing tokens like `parse`, `parseClaimsJws`, and `parsePlaintextJws`. The last two correctly verify that the JWT is properly signed. This is done by computing the signature of the combination of header and payload and comparing the locally computed signature with the signature part of the JWT.\n\nTherefore it is necessary to provide the `JwtParser` with a key that is used for signature validation. Unfortunately the `parse` method **accepts** a JWT whose signature is empty although a signing key has been set for the parser. This means that an attacker can create arbitrary JWTs that will be accepted if this method is used.\n\n\n## Recommendation\nAlways verify the signature by using either the `parseClaimsJws` and `parsePlaintextJws` methods or by overriding the `onPlaintextJws` or `onClaimsJws` of `JwtHandlerAdapter`.\n\n\n## Example\nThe following example shows four cases where a signing key is set for a parser. In the first 'BAD' case the `parse` method is used, which will not validate the signature. The second 'BAD' case uses a `JwtHandlerAdapter` where the `onPlaintextJwt` method is overriden, so it will not validate the signature. The third and fourth 'GOOD' cases use `parseClaimsJws` method or override the `onPlaintextJws` method.\n\n\n```java\npublic void badJwt(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parse(token); // BAD: Does not verify the signature\n}\n\npublic void badJwtHandler(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parse(plaintextJwt, new JwtHandlerAdapter<Jwt<Header, String>>() {\n                    @Override\n                    public Jwt<Header, String> onPlaintextJwt(Jwt<Header, String> jwt) {\n                        return jwt;\n                    }\n                }); // BAD: The handler is called on an unverified JWT\n}\n\npublic void goodJwt(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parseClaimsJws(token) // GOOD: Verify the signature\n                .getBody();\n}\n\npublic void goodJwtHandler(String token) {\n    Jwts.parserBuilder()\n                .setSigningKey(\"someBase64EncodedKey\").build()\n                .parse(plaintextJwt, new JwtHandlerAdapter<Jws<String>>() {\n                    @Override\n                    public Jws<String> onPlaintextJws(Jws<String> jws) {\n                        return jws;\n                    }\n                }); // GOOD: The handler is called on a verified JWS\n}\n```\n\n## References\n* zofrex: [How I Found An alg=none JWT Vulnerability in the NHS Contact Tracing App](https://www.zofrex.com/blog/2020/10/20/alg-none-jwt-nhs-contact-tracing-app/).\n* Common Weakness Enumeration: [CWE-347](https://cwe.mitre.org/data/definitions/347.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-347"
+                                    ],
+                                    "description": "Failing to check the Json Web Token (JWT) signature may allow an attacker to forge their own tokens.",
+                                    "id": "java/missing-jwt-signature-check",
+                                    "kind": "path-problem",
+                                    "name": "Missing JWT signature check",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "7.8"
+                                }
+                            },
+                            {
+                                "id": "java/xss",
+                                "name": "java/xss",
+                                "shortDescription": {
+                                    "text": "Cross-site scripting"
+                                },
+                                "fullDescription": {
+                                    "text": "Writing user input directly to a web page allows for a cross-site scripting vulnerability."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Cross-site scripting\nDirectly writing user input (for example, an HTTP request parameter) to a web page, without properly sanitizing the input first, allows for a cross-site scripting vulnerability.\n\n\n## Recommendation\nTo guard against cross-site scripting, consider using contextual output encoding/escaping before writing user input to the page, or one of the other solutions that are mentioned in the reference.\n\n\n## Example\nThe following example shows the `page` parameter being written directly to the page, leaving the website vulnerable to cross-site scripting.\n\n\n```java\npublic class XSS extends HttpServlet {\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: a request parameter is written directly to the Servlet response stream\n\t\tresponse.getWriter().print(\n\t\t\t\t\"The page \\\"\" + request.getParameter(\"page\") + \"\\\" was not found.\");\n\n\t}\n}\n\n```\n\n## References\n* OWASP: [XSS (Cross Site Scripting) Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html).\n* Wikipedia: [Cross-site scripting](http://en.wikipedia.org/wiki/Cross-site_scripting).\n* Common Weakness Enumeration: [CWE-79](https://cwe.mitre.org/data/definitions/79.html).\n",
+                                    "markdown": "# Cross-site scripting\nDirectly writing user input (for example, an HTTP request parameter) to a web page, without properly sanitizing the input first, allows for a cross-site scripting vulnerability.\n\n\n## Recommendation\nTo guard against cross-site scripting, consider using contextual output encoding/escaping before writing user input to the page, or one of the other solutions that are mentioned in the reference.\n\n\n## Example\nThe following example shows the `page` parameter being written directly to the page, leaving the website vulnerable to cross-site scripting.\n\n\n```java\npublic class XSS extends HttpServlet {\n\tprotected void doGet(HttpServletRequest request, HttpServletResponse response)\n\tthrows ServletException, IOException {\n\t\t// BAD: a request parameter is written directly to the Servlet response stream\n\t\tresponse.getWriter().print(\n\t\t\t\t\"The page \\\"\" + request.getParameter(\"page\") + \"\\\" was not found.\");\n\n\t}\n}\n\n```\n\n## References\n* OWASP: [XSS (Cross Site Scripting) Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html).\n* Wikipedia: [Cross-site scripting](http://en.wikipedia.org/wiki/Cross-site_scripting).\n* Common Weakness Enumeration: [CWE-79](https://cwe.mitre.org/data/definitions/79.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-079"
+                                    ],
+                                    "description": "Writing user input directly to a web page\n              allows for a cross-site scripting vulnerability.",
+                                    "id": "java/xss",
+                                    "kind": "path-problem",
+                                    "name": "Cross-site scripting",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "6.1"
+                                }
+                            },
+                            {
+                                "id": "java/insecure-cookie",
+                                "name": "java/insecure-cookie",
+                                "shortDescription": {
+                                    "text": "Failure to use secure cookies"
+                                },
+                                "fullDescription": {
+                                    "text": "Insecure cookies may be sent in cleartext, which makes them vulnerable to interception."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "error"
+                                },
+                                "help": {
+                                    "text": "# Failure to use secure cookies\nFailing to set the 'secure' flag on a cookie can cause it to be sent in cleartext. This makes it easier for an attacker to intercept.\n\n\n## Recommendation\nAlways use `setSecure` to set the 'secure' flag on a cookie before adding it to an `HttpServletResponse`.\n\n\n## Example\nThis example shows two ways of adding a cookie to an `HttpServletResponse`. The first way leaves out the setting of the 'secure' flag; the second way includes the setting of the flag.\n\n\n```java\npublic static void test(HttpServletRequest request, HttpServletResponse response) {\n\t{\n\t\tCookie cookie = new Cookie(\"secret\", \"fakesecret\");\n\t\t\n\t\t// BAD: 'secure' flag not set\n\t\tresponse.addCookie(cookie);\n\t}\n\n\t{\n\t\tCookie cookie = new Cookie(\"secret\", \"fakesecret\");\n\t\t\n\t\t// GOOD: set 'secure' flag\n\t\tcookie.setSecure(true);\n\t\tresponse.addCookie(cookie);\n\t}\n}\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [SER03-J. Do not serialize unencrypted, sensitive data](https://wiki.sei.cmu.edu/confluence/display/java/SER03-J.+Do+not+serialize+unencrypted+sensitive+data).\n* Java Platform, Enterprise Edition (Java EE) 7, API Specification: [Class Cookie](https://docs.oracle.com/javaee/7/api/javax/servlet/http/Cookie.html).\n* Common Weakness Enumeration: [CWE-614](https://cwe.mitre.org/data/definitions/614.html).\n",
+                                    "markdown": "# Failure to use secure cookies\nFailing to set the 'secure' flag on a cookie can cause it to be sent in cleartext. This makes it easier for an attacker to intercept.\n\n\n## Recommendation\nAlways use `setSecure` to set the 'secure' flag on a cookie before adding it to an `HttpServletResponse`.\n\n\n## Example\nThis example shows two ways of adding a cookie to an `HttpServletResponse`. The first way leaves out the setting of the 'secure' flag; the second way includes the setting of the flag.\n\n\n```java\npublic static void test(HttpServletRequest request, HttpServletResponse response) {\n\t{\n\t\tCookie cookie = new Cookie(\"secret\", \"fakesecret\");\n\t\t\n\t\t// BAD: 'secure' flag not set\n\t\tresponse.addCookie(cookie);\n\t}\n\n\t{\n\t\tCookie cookie = new Cookie(\"secret\", \"fakesecret\");\n\t\t\n\t\t// GOOD: set 'secure' flag\n\t\tcookie.setSecure(true);\n\t\tresponse.addCookie(cookie);\n\t}\n}\n```\n\n## References\n* SEI CERT Oracle Coding Standard for Java: [SER03-J. Do not serialize unencrypted, sensitive data](https://wiki.sei.cmu.edu/confluence/display/java/SER03-J.+Do+not+serialize+unencrypted+sensitive+data).\n* Java Platform, Enterprise Edition (Java EE) 7, API Specification: [Class Cookie](https://docs.oracle.com/javaee/7/api/javax/servlet/http/Cookie.html).\n* Common Weakness Enumeration: [CWE-614](https://cwe.mitre.org/data/definitions/614.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-614"
+                                    ],
+                                    "description": "Insecure cookies may be sent in cleartext, which makes them vulnerable to\n              interception.",
+                                    "id": "java/insecure-cookie",
+                                    "kind": "problem",
+                                    "name": "Failure to use secure cookies",
+                                    "precision": "high",
+                                    "problem.severity": "error",
+                                    "security-severity": "5.0"
+                                }
+                            },
+                            {
+                                "id": "java/insufficient-key-size",
+                                "name": "java/insufficient-key-size",
+                                "shortDescription": {
+                                    "text": "Use of a cryptographic algorithm with insufficient key size"
+                                },
+                                "fullDescription": {
+                                    "text": "Using cryptographic algorithms with too small a key size can allow an attacker to compromise security."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true,
+                                    "level": "warning"
+                                },
+                                "help": {
+                                    "text": "# Use of a cryptographic algorithm with insufficient key size\nModern encryption relies on the computational infeasibility of breaking a cipher and decoding its message without the key. As computational power increases, the ability to break ciphers grows, and key sizes need to become larger as a result. Cryptographic algorithms that use too small of a key size are vulnerable to brute force attacks, which can reveal sensitive data.\n\n\n## Recommendation\nUse a key of the recommended size or larger. The key size should be at least 128 bits for AES encryption, 256 bits for elliptic-curve cryptography (ECC), and 2048 bits for RSA, DSA, or DH encryption.\n\n\n## Example\nThe following code uses cryptographic algorithms with insufficient key sizes.\n\n\n```java\n    KeyPairGenerator keyPairGen1 = KeyPairGenerator.getInstance(\"RSA\");\n    keyPairGen1.initialize(1024); // BAD: Key size is less than 2048\n\n    KeyPairGenerator keyPairGen2 = KeyPairGenerator.getInstance(\"DSA\");\n    keyPairGen2.initialize(1024); // BAD: Key size is less than 2048\n\n    KeyPairGenerator keyPairGen3 = KeyPairGenerator.getInstance(\"DH\");\n    keyPairGen3.initialize(1024); // BAD: Key size is less than 2048\n\n    KeyPairGenerator keyPairGen4 = KeyPairGenerator.getInstance(\"EC\");\n    ECGenParameterSpec ecSpec = new ECGenParameterSpec(\"secp112r1\"); // BAD: Key size is less than 256\n    keyPairGen4.initialize(ecSpec);\n\n    KeyGenerator keyGen = KeyGenerator.getInstance(\"AES\");\n    keyGen.init(64); // BAD: Key size is less than 128\n\n```\nTo fix the code, change the key sizes to be the recommended size or larger for each algorithm.\n\n\n## References\n* Wikipedia: [Key size](http://en.wikipedia.org/wiki/Key_size).\n* Wikipedia: [Strong cryptography](https://en.wikipedia.org/wiki/Strong_cryptography).\n* OWASP: [ Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#algorithms).\n* OWASP: [ Testing for Weak Encryption](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption).\n* NIST: [ Transitioning the Use of Cryptographic Algorithms and Key Lengths](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf).\n* Common Weakness Enumeration: [CWE-326](https://cwe.mitre.org/data/definitions/326.html).\n",
+                                    "markdown": "# Use of a cryptographic algorithm with insufficient key size\nModern encryption relies on the computational infeasibility of breaking a cipher and decoding its message without the key. As computational power increases, the ability to break ciphers grows, and key sizes need to become larger as a result. Cryptographic algorithms that use too small of a key size are vulnerable to brute force attacks, which can reveal sensitive data.\n\n\n## Recommendation\nUse a key of the recommended size or larger. The key size should be at least 128 bits for AES encryption, 256 bits for elliptic-curve cryptography (ECC), and 2048 bits for RSA, DSA, or DH encryption.\n\n\n## Example\nThe following code uses cryptographic algorithms with insufficient key sizes.\n\n\n```java\n    KeyPairGenerator keyPairGen1 = KeyPairGenerator.getInstance(\"RSA\");\n    keyPairGen1.initialize(1024); // BAD: Key size is less than 2048\n\n    KeyPairGenerator keyPairGen2 = KeyPairGenerator.getInstance(\"DSA\");\n    keyPairGen2.initialize(1024); // BAD: Key size is less than 2048\n\n    KeyPairGenerator keyPairGen3 = KeyPairGenerator.getInstance(\"DH\");\n    keyPairGen3.initialize(1024); // BAD: Key size is less than 2048\n\n    KeyPairGenerator keyPairGen4 = KeyPairGenerator.getInstance(\"EC\");\n    ECGenParameterSpec ecSpec = new ECGenParameterSpec(\"secp112r1\"); // BAD: Key size is less than 256\n    keyPairGen4.initialize(ecSpec);\n\n    KeyGenerator keyGen = KeyGenerator.getInstance(\"AES\");\n    keyGen.init(64); // BAD: Key size is less than 128\n\n```\nTo fix the code, change the key sizes to be the recommended size or larger for each algorithm.\n\n\n## References\n* Wikipedia: [Key size](http://en.wikipedia.org/wiki/Key_size).\n* Wikipedia: [Strong cryptography](https://en.wikipedia.org/wiki/Strong_cryptography).\n* OWASP: [ Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#algorithms).\n* OWASP: [ Testing for Weak Encryption](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/04-Testing_for_Weak_Encryption).\n* NIST: [ Transitioning the Use of Cryptographic Algorithms and Key Lengths](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf).\n* Common Weakness Enumeration: [CWE-326](https://cwe.mitre.org/data/definitions/326.html).\n"
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "security",
+                                        "external/cwe/cwe-326"
+                                    ],
+                                    "description": "Using cryptographic algorithms with too small a key size can\n              allow an attacker to compromise security.",
+                                    "id": "java/insufficient-key-size",
+                                    "kind": "path-problem",
+                                    "name": "Use of a cryptographic algorithm with insufficient key size",
+                                    "precision": "high",
+                                    "problem.severity": "warning",
+                                    "security-severity": "7.5"
+                                }
+                            },
+                            {
+                                "id": "java/telemetry/supported-external-api-sources",
+                                "name": "java/telemetry/supported-external-api-sources",
+                                "shortDescription": {
+                                    "text": "Supported sources in external libraries"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of 3rd party APIs detected as sources. Excludes test and generated code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "telemetry"
+                                    ],
+                                    "description": "A list of 3rd party APIs detected as sources. Excludes test and generated code.",
+                                    "id": "java/telemetry/supported-external-api-sources",
+                                    "kind": "metric",
+                                    "name": "Supported sources in external libraries"
+                                }
+                            },
+                            {
+                                "id": "java/telemetry/supported-external-api",
+                                "name": "java/telemetry/supported-external-api",
+                                "shortDescription": {
+                                    "text": "Usage of supported APIs coming from external libraries"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of supported 3rd party APIs used in the codebase. Excludes test and generated code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "telemetry"
+                                    ],
+                                    "description": "A list of supported 3rd party APIs used in the codebase. Excludes test and generated code.",
+                                    "id": "java/telemetry/supported-external-api",
+                                    "kind": "metric",
+                                    "name": "Usage of supported APIs coming from external libraries"
+                                }
+                            },
+                            {
+                                "id": "java/telemetry/extraction-information",
+                                "name": "java/telemetry/extraction-information",
+                                "shortDescription": {
+                                    "text": "Java extraction information"
+                                },
+                                "fullDescription": {
+                                    "text": "Information about the extraction for a Java database"
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "telemetry"
+                                    ],
+                                    "description": "Information about the extraction for a Java database",
+                                    "id": "java/telemetry/extraction-information",
+                                    "kind": "metric",
+                                    "name": "Java extraction information"
+                                }
+                            },
+                            {
+                                "id": "java/telemetry/supported-external-api-taint",
+                                "name": "java/telemetry/supported-external-api-taint",
+                                "shortDescription": {
+                                    "text": "Supported flow steps in external libraries"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of 3rd party APIs detected as flow steps. Excludes test and generated code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "telemetry"
+                                    ],
+                                    "description": "A list of 3rd party APIs detected as flow steps. Excludes test and generated code.",
+                                    "id": "java/telemetry/supported-external-api-taint",
+                                    "kind": "metric",
+                                    "name": "Supported flow steps in external libraries"
+                                }
+                            },
+                            {
+                                "id": "java/telemetry/supported-external-api-sinks",
+                                "name": "java/telemetry/supported-external-api-sinks",
+                                "shortDescription": {
+                                    "text": "Supported sinks in external libraries"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of 3rd party APIs detected as sinks. Excludes test and generated code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "telemetry"
+                                    ],
+                                    "description": "A list of 3rd party APIs detected as sinks. Excludes test and generated code.",
+                                    "id": "java/telemetry/supported-external-api-sinks",
+                                    "kind": "metric",
+                                    "name": "Supported sinks in external libraries"
+                                }
+                            },
+                            {
+                                "id": "java/telemetry/external-libs",
+                                "name": "java/telemetry/external-libs",
+                                "shortDescription": {
+                                    "text": "External libraries"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of external libraries used in the code"
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "telemetry"
+                                    ],
+                                    "description": "A list of external libraries used in the code",
+                                    "id": "java/telemetry/external-libs",
+                                    "kind": "metric",
+                                    "name": "External libraries"
+                                }
+                            },
+                            {
+                                "id": "java/telemetry/unsupported-external-api",
+                                "name": "java/telemetry/unsupported-external-api",
+                                "shortDescription": {
+                                    "text": "Usage of unsupported APIs coming from external libraries"
+                                },
+                                "fullDescription": {
+                                    "text": "A list of 3rd party APIs used in the codebase. Excludes test and generated code."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "telemetry"
+                                    ],
+                                    "description": "A list of 3rd party APIs used in the codebase. Excludes test and generated code.",
+                                    "id": "java/telemetry/unsupported-external-api",
+                                    "kind": "metric",
+                                    "name": "Usage of unsupported APIs coming from external libraries"
+                                }
+                            },
+                            {
+                                "id": "java/summary/lines-of-code",
+                                "name": "java/summary/lines-of-code",
+                                "shortDescription": {
+                                    "text": "Total lines of Java code in the database"
+                                },
+                                "fullDescription": {
+                                    "text": "The total number of lines of code across all files. This is a useful metric of the size of a database. For all files that were seen during the build, this query counts the lines of code, excluding whitespace or comments."
+                                },
+                                "defaultConfiguration": {
+                                    "enabled": true
+                                },
+                                "properties": {
+                                    "tags": [
+                                        "summary",
+                                        "lines-of-code"
+                                    ],
+                                    "description": "The total number of lines of code across all files. This is a useful metric of the size of a database.\n              For all files that were seen during the build, this query counts the lines of code, excluding whitespace\n              or comments.",
+                                    "id": "java/summary/lines-of-code",
+                                    "kind": "metric",
+                                    "name": "Total lines of Java code in the database"
+                                }
+                            }
+                        ],
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/java-queries/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/java-queries/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/ruby-queries",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ruby-queries/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ruby-queries/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/csharp-examples",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/csharp-examples/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/csharp-examples/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/tutorial",
+                        "semanticVersion": "0.0.6+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/tutorial/0.0.6/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/tutorial/0.0.6/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/regex",
+                        "semanticVersion": "0.0.9+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/regex/0.0.9/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/regex/0.0.9/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/ruby-all",
+                        "semanticVersion": "0.5.5+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ruby-all/0.5.5/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/ruby-all/0.5.5/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/util",
+                        "semanticVersion": "0.0.6+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/util/0.0.6/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/util/0.0.6/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/cpp-examples",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/cpp-examples/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/cpp-examples/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/python-examples",
+                        "semanticVersion": "0.0.0+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/python-examples/0.0.0/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/python-examples/0.0.0/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "legacy-upgrades",
+                        "semanticVersion": "0.0.0",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/legacy-upgrades/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/legacy-upgrades/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "codeql/typos",
+                        "semanticVersion": "0.0.13+940e492766cb4e7e756b920daefcc54f6451f011",
+                        "locations": [
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/typos/0.0.13/",
+                                "description": {
+                                    "text": "The QL pack root directory."
+                                }
+                            },
+                            {
+                                "uri": "file:///opt/hostedtoolcache/CodeQL/2.12.5-20230317/x64/codeql/qlpacks/codeql/typos/0.0.13/qlpack.yml",
+                                "description": {
+                                    "text": "The QL pack definition file."
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "invocations": [
+                {
+                    "toolExecutionNotifications": [
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00409.java",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 561
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "java/diagnostics/successfully-extracted-files",
+                                "index": 0,
+                                "toolComponent": {
+                                    "index": 20
+                                }
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00725.java",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 1415
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "java/diagnostics/successfully-extracted-files",
+                                "index": 0,
+                                "toolComponent": {
+                                    "index": 20
+                                }
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01753.java",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 1942
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "java/diagnostics/successfully-extracted-files",
+                                "index": 0,
+                                "toolComponent": {
+                                    "index": 20
+                                }
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00387.java",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 1319
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "java/diagnostics/successfully-extracted-files",
+                                "index": 0,
+                                "toolComponent": {
+                                    "index": 20
+                                }
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01437.java",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 1600
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "java/diagnostics/successfully-extracted-files",
+                                "index": 0,
+                                "toolComponent": {
+                                    "index": 20
+                                }
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        },
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01268.java",
+                                            "uriBaseId": "%SRCROOT%",
+                                            "index": 1548
+                                        }
+                                    }
+                                }
+                            ],
+                            "message": {
+                                "text": ""
+                            },
+                            "level": "none",
+                            "descriptor": {
+                                "id": "java/diagnostics/successfully-extracted-files",
+                                "index": 0,
+                                "toolComponent": {
+                                    "index": 20
+                                }
+                            },
+                            "properties": {
+                                "formattedMessage": {
+                                    "text": ""
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- ensure the rules are properly parsed (need to take `extensions` into account)
- ensure the parser only handles CodeQL sarif files (and support .json/.sarif equally well).
- removed LGTM prefix for clarity 
- sample file added to test resources