### PR TITLE
fix(SnykReader): fix incorrect mapping of cwe-1004 to cwe-614

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SnykReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SnykReader.java
@@ -22,7 +22,7 @@ public class SnykReader extends Reader {
                     put("Sqli", CweNumber.SQL_INJECTION);
                     put("PT", CweNumber.PATH_TRAVERSAL);
                     put("HardcodedPassword", 0);
-                    put("WebCookieMissesCallToSetHttpOnly", CweNumber.INSECURE_COOKIE);
+                    put("WebCookieMissesCallToSetHttpOnly", CweNumber.COOKIE_WITHOUT_HTTPONLY);
                     put("ServerInformationExposure", 0);
                     put("UserControlledFormatString", CweNumber.EXTERNALLY_CONTROLLED_STRING);
                     put("SpringCSRF", CweNumber.CSRF);


### PR DESCRIPTION
Snyk's "WebCookieMissesCallToSetHttpOnly" rule id corresponds to cwe-1004, not to cwe-614, as the mapping to 'CweNumber.INSECURE_COOKIE' would suggest.