### PR TITLE
Enhance FluidAttacks reader's canRead method to not detect Semgrep by mistake

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/FluidAttacksReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/FluidAttacksReader.java
@@ -29,7 +29,8 @@ public class FluidAttacksReader extends Reader {
 
     @Override
     public boolean canRead(ResultFile resultFile) {
-        return resultFile.line(0).contains("cwe") && resultFile.line(0).contains("what");
+        return resultFile.filename().endsWith("csv")
+                && resultFile.line(0).trim().equals("title,what,where,cwe");
     }
 
     @Override

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/TestHelper.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/TestHelper.java
@@ -19,6 +19,7 @@ package org.owasp.benchmarkutils.score;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.Objects;
 import org.apache.commons.io.IOUtils;
 
@@ -35,6 +36,23 @@ public class TestHelper {
     public static byte[] contentOf(String filename) {
         try {
             return IOUtils.toByteArray(asStream(filename));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static ResultFile resultFileWithoutLineBreaksOf(String filename) {
+        try {
+            return new ResultFile(filename, contentWithoutLineBreaksOf(filename));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String contentWithoutLineBreaksOf(String filename) {
+        try {
+            return IOUtils.toString(asStream(filename), Charset.defaultCharset())
+                    .replace('\n', ' ');
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/SemgrepReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/SemgrepReaderTest.java
@@ -36,7 +36,9 @@ public class SemgrepReaderTest extends ReaderTestBase {
     @BeforeEach
     void setUp() {
         resultFileV65 = TestHelper.resultFileOf("testfiles/Benchmark_semgrep-v0.65.0.json");
-        resultFileV121 = TestHelper.resultFileOf("testfiles/Benchmark_semgrep-v0.121.0.json");
+        resultFileV121 =
+                TestHelper.resultFileWithoutLineBreaksOf(
+                        "testfiles/Benchmark_semgrep-v0.121.0.json");
         BenchmarkScore.TESTCASENAME = "BenchmarkTest";
     }
 

--- a/plugin/src/test/resources/testfiles/Benchmark_semgrep-v0.121.0.json
+++ b/plugin/src/test/resources/testfiles/Benchmark_semgrep-v0.121.0.json
@@ -12,7 +12,7 @@
         "fingerprint": "b04b2629a927ec0c62a65dbf719260f058c7591b15db57c22eaa4c0d50068efa3731782ca98ff43f75f99a17de166835c74b932b5bc35c709e09a19f83328056_0",
         "is_ignored": false,
         "lines": "            Process p = r.exec(cmd + param);",
-        "message": "A formatted or concatenated string was detected as input to a java.lang.Runtime call. This is dangerous if a variable is controlled by user input and could result in a command injection. Ensure your variables are not controlled by users or sufficiently sanitized.",
+        "message": "A formatted or concatenated string was detected as input to a java.lang.Runtime call. This is dangerous if a variable is controlled by user input and could result in a command injection. Ensure your variables are not controlled by users or sufficiently sanitized. 'what'",
         "metadata": {
           "category": "security",
           "confidence": "LOW",


### PR DESCRIPTION
This adresses issue https://github.com/OWASP-Benchmark/BenchmarkJava/issues/199.

![toolresults_comparison](https://github.com/OWASP-Benchmark/BenchmarkUtils/assets/17259447/b6740327-fcb2-457c-a748-b54809b5bf0e)
