### PR TITLE
Fixes for HCLAppScanStandard XML Parser

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReader.java
@@ -70,43 +70,64 @@ public class HCLAppScanStandardReader extends Reader {
         if (version != null) {
             tr.setToolVersion(version.getTextContent().split(" ")[0]);
         }
-
-        Node allIssues = getNamedChild("url-group", root);
-        List<Node> vulnerabilities = getNamedChildren("item", allIssues);
-
+        
         Node allIssueVariants = getNamedChild("issue-group", root);
         List<Node> variants = getNamedChildren("item", allIssueVariants);
+        
+        List<String> testCaseElementsFromVariants = new ArrayList<>();
+        
+        
+        if (variants.isEmpty()) {
+            // Handle non-variant issue types , Older xml format as in 9.x release versions and
+            // before
+            // First get the type of vuln, and if we don't care about that type, move on
+        	 Node allIssues = getNamedChild("url-group", root);
+        	 List<Node> vulnerabilities = getNamedChildren("item", allIssues);
+        	 for (Node vulnerability : vulnerabilities) {
+                 String issueType = getNamedChild("issue-type", vulnerability).getTextContent();
 
-        // Loop through all the vulnerabilities
-        for (Node vulnerability : vulnerabilities) {
-            String issueType = getNamedChild("issue-type", vulnerability).getTextContent();
-
-            String url = getNamedChild("name", vulnerability).getTextContent();
-            // to give DAST tools some credit, if they report a similar vuln in a different area, we
-            // count it.
-            // e.g., SQLi in the XPATHi tests. To do that, we have to pull out the vuln type from
-            // the URL.
-
-            NamedNodeMap itemNode = vulnerability.getAttributes();
-            String variantItemID = itemNode.getNamedItem("id").getNodeValue();
-
-            List<String> testCaseElementsFromVariants =
-                    variantLookup(issueType, variantItemID, startingUrl, variants);
-            if (testCaseElementsFromVariants.isEmpty()) {
-                // Handle non-variant issue types , Older xml format as in 9.x release versions and
-                // before
-                // First get the type of vuln, and if we don't care about that type, move on
-                TestCaseResult tcr = TestCaseLookup(issueType, url);
-                if (tcr != null) tr.put(tcr);
-            } else {
-                // Handle issues which are Variants, new xml format after 10.x release
-                for (String testArea : testCaseElementsFromVariants) {
-                    TestCaseResult tcr = TestCaseLookup(issueType, testArea);
-                    if (tcr != null) tr.put(tcr);
-                }
+                 String url = getNamedChild("name", vulnerability).getTextContent();
+                 
+            TestCaseResult tcr = TestCaseLookup(issueType, url);
+            if (tcr != null) tr.put(tcr);
+        	 }
+        }
+        
+        else {
+            // Handle issues which are Variants, new xml format after 10.x release
+        	for (Node variant : variants) {
+	            String variantIssueType = getNamedChild("issue-type", variant).getTextContent().trim();
+	            // System.out.println("Variant Url Ref ID: " + variantUrlRefId);
+	
+	            // Add the record only if the issue type matches for the relevant variants
+	                Node variantNodes = getNamedChild("variant-group", variant);
+	                List<Node> variantNodeChildren = getNamedChildren("item", variantNodes);
+	                for (Node variantNodeChild : variantNodeChildren) {
+	                    String httpTraffic =
+	                            getNamedChild("test-http-traffic", variantNodeChild).getTextContent();
+	                    String[] variantUrl = httpTraffic.split(" ");
+	
+	                    String benchMarkTestCase = variantUrl[1].trim();
+	
+	                    if (benchMarkTestCase.contains("BenchmarkTest")) {
+	                        String[] urlElements = benchMarkTestCase.split("/");
+	
+	                        String testAreaUrl =
+	                                startingUrl
+	                                        + urlElements[urlElements.length - 2]
+	                                        + "/"
+	                                        + urlElements[urlElements.length - 1];
+	                        String testArea = testAreaUrl.split("\\?")[0]; // .split strips off the -##
+	
+	                        if (testArea.contains("BenchmarkTest"))
+	                            testCaseElementsFromVariants.add(testArea);
+			                    TestCaseResult tcr = TestCaseLookup(variantIssueType, testArea);
+			                    if (tcr != null) 
+			                    	tr.put(tcr);
+	                    }
+	                }
             }
         }
-
         return tr;
     }
 

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReaderTest.java
@@ -54,9 +54,11 @@ public class HCLAppScanStandardReaderTest extends ReaderTestBase {
         assertEquals("HCL AppScan Standard", result.getToolName());
         assertEquals("10.0.6", result.getToolVersion());
 
-        assertEquals(2, result.getTotalResults());
+        assertEquals(4, result.getTotalResults());
 
         assertEquals(CweNumber.SQL_INJECTION, result.get(1).get(0).getCWE());
         assertEquals(CweNumber.SQL_INJECTION, result.get(2).get(0).getCWE());
+        assertEquals(CweNumber.INSECURE_COOKIE, result.get(300).get(0).getCWE());
+        assertEquals(CweNumber.INSECURE_COOKIE, result.get(348).get(0).getCWE());
     }
 }

--- a/plugin/src/test/resources/testfiles/Benchmark_HCLAppScanStandardReader-v10.0.6.xml
+++ b/plugin/src/test/resources/testfiles/Benchmark_HCLAppScanStandardReader-v10.0.6.xml
@@ -19,8 +19,12 @@
             <name>https://localhost:8443/benchmark/sqli-00/BenchmarkTest00002</name>
             <issue-type>attSqlInjectionChecks</issue-type>
         </item>
+        <item id="3333333333">
+            <name>https://localhost:8443/</name>
+            <issue-type>attSameSiteCookie</issue-type>
+        </item>
     </url-group>
-    <issue-group total="2">
+    <issue-group total="4">
         <item id="1234567890" id-v2="-1234567890">
             <cwe>89</cwe>
             <issue-type>
@@ -37,6 +41,23 @@
                 </item>
                 <item id="2222222222">
                     <test-http-traffic>POST /benchmark/sqli-00/BenchmarkTest00002 HTTP/1.1</test-http-traffic>
+                </item>
+            </variant-group>
+        </item>
+        <item id="2345678901" id-v2="-2345678901">
+            <cwe>614</cwe>
+            <issue-type>
+                <ref>attRespCookieNotSecureSSL</ref>
+            </issue-type>
+            <url>
+                <ref>3333333333</ref>
+            </url>
+            <variant-group>
+                <item id="3333333333">
+                    <test-http-traffic>POST /benchmark/securecookie-00/BenchmarkTest00300 HTTP/1.1</test-http-traffic>
+                </item>
+                <item id="4444444444">
+                    <test-http-traffic>POST /benchmark/securecookie-00/BenchmarkTest00348 HTTP/1.1</test-http-traffic>
                 </item>
             </variant-group>
         </item>


### PR DESCRIPTION
Changes in the parser to avoid missing out on few detections ("variants") in the new XML format (10.x)