### PR TITLE
fix: mvn install fails on Windows

### DIFF
--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/BenchmarkScoreTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/BenchmarkScoreTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 public class BenchmarkScoreTest {
 
+    private static final String SEP = System.getProperty("line.separator");
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
 
@@ -32,7 +33,7 @@ public class BenchmarkScoreTest {
     }
 
     private void expectDefaultConfigAndUsageMessage() {
-        String[] resultLines = outContent.toString().split("\n");
+        String[] resultLines = outContent.toString().split(SEP);
 
         assertEquals(2, resultLines.length);
         assertEquals(BenchmarkScore.USAGE_MSG, resultLines[0]);
@@ -77,7 +78,7 @@ public class BenchmarkScoreTest {
     }
 
     private void expectUsageMessage() {
-        String[] resultLines = outContent.toString().split("\n");
+        String[] resultLines = outContent.toString().split(SEP);
 
         assertEquals(1, resultLines.length);
         assertEquals(BenchmarkScore.USAGE_MSG, resultLines[0]);

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/ConfigurationTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/ConfigurationTest.java
@@ -41,6 +41,7 @@ public class ConfigurationTest {
     private Yaml yaml;
     private final ClassLoader classLoader = Configuration.class.getClassLoader();
     private ByteArrayOutputStream out;
+    private static final String SEP = System.getProperty("line.separator");
 
     @BeforeEach
     public void setUp() {
@@ -78,8 +79,8 @@ public class ConfigurationTest {
     @Test
     void informsAboutDefaultConfig() {
         Configuration.fromDefaultConfig();
-
-        assertEquals("INFO: Default YAML Scoring config file found and loaded.\n", out.toString());
+        assertEquals(
+                "INFO: Default YAML Scoring config file found and loaded." + SEP, out.toString());
     }
 
     @Test
@@ -92,7 +93,7 @@ public class ConfigurationTest {
     void informsAboutResourceConfig() {
         Configuration.fromResourceFile(Configuration.DEFAULT_CONFIG);
 
-        assertEquals("INFO: YAML Scoring config file found and loaded.\n", out.toString());
+        assertEquals("INFO: YAML Scoring config file found and loaded." + SEP, out.toString());
     }
 
     @Test
@@ -143,7 +144,7 @@ public class ConfigurationTest {
     void informsAboutFileConfig() throws Exception {
         Configuration.fromFile(provideEmptyConfig().getAbsolutePath());
 
-        assertEquals("INFO: YAML Scoring config file found and loaded.\n", out.toString());
+        assertEquals("INFO: YAML Scoring config file found and loaded." + SEP, out.toString());
     }
 
     @Test


### PR DESCRIPTION
Running `mvn install` fails on windows PCs because of different line endings.

This PR fixes that issue.

example error: 
<details>

```
[ERROR] org.owasp.benchmarkutils.score.ConfigurationTest.informsAboutResourceConfig -- Time elapsed: 0.003 s <<< FAILURE!
org.opentest4j.AssertionFailedError:
expected: <INFO: YAML Scoring config file found and loaded.
> but was: <INFO: YAML Scoring config file found and loaded.
>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1141)
        at org.owasp.benchmarkutils.score.ConfigurationTest.informsAboutResourceConfig(ConfigurationTest.java:95)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at java.util.ArrayList.forEach(ArrayList.java:1259)
        at java.util.ArrayList.forEach(ArrayList.java:1259)
```

<\details>