### PR TITLE
CodeQL: Add CWE-501 (Trust Boundary Violation)

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CodeQLReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CodeQLReader.java
@@ -228,6 +228,7 @@ public class CodeQLReader extends Reader {
             case 89: // java & js/sql-injection and similar sqli rules
             case 90: // java/ldap-injection
             case 327: // java/weak-cryptographic-algorithm
+            case 501: // java/trust-boundary-violation
             case 611: // java & js/xxe
             case 614: // java/insecure-cookie
             case 643: // java/xml/xpath-injection


### PR DESCRIPTION
As of https://github.com/github/codeql/pull/13413, CodeQL for Java covers CWE-501.

This adds CWE-501 to the `CodeQLReader` class.