### PR TITLE
CodeQL: Add support for CodeQL's handling of CWE-327/328

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
@@ -848,8 +848,11 @@ public class BenchmarkScore extends AbstractMojo {
                 match = (actualCWE == 89);
             }
 
-            // special hack since IBM/Veracode don't distinguish different kinds of weak algorithm
-            if (tool.startsWith("AppScan") || tool.startsWith("Vera")) {
+            // special hack since IBM/Veracode and CodeQL don't distinguish different kinds of weak
+            // algorithm
+            if (tool.startsWith("AppScan")
+                    || tool.startsWith("Vera")
+                    || tool.startsWith("CodeQL")) {
                 if (expectedCWE == 328 && actualCWE == 327) {
                     match = true;
                 }


### PR DESCRIPTION
CodeQL for Java does not distinguish between [CWE-327] and [CWE-328]. This adds CodeQL to the list of tools which do not distinguish between weak encryption and weak hashing.

[CWE-327]: https://cwe.mitre.org/data/definitions/327
[CWE-328]: https://cwe.mitre.org/data/definitions/328