### PR TITLE
Extract overall stats table

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/Tool.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/Tool.java
@@ -19,7 +19,6 @@ package org.owasp.benchmarkutils.score;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Map;
 import org.owasp.benchmarkutils.score.TestSuiteResults.ToolType;
@@ -53,8 +52,7 @@ public class Tool implements Comparable<Tool> {
             Map<String, TP_FN_TN_FP_Counts> scores,
             ToolResults toolResults,
             String actualCSVResultsFileName,
-            boolean isCommercial)
-            throws IOException, URISyntaxException {
+            boolean isCommercial) {
 
         this.isCommercial = isCommercial;
         this.toolType = actualResults.toolType;

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/Formats.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/Formats.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.report;
 
 import java.text.DecimalFormat;

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/Formats.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/Formats.java
@@ -1,0 +1,9 @@
+package org.owasp.benchmarkutils.score.report;
+
+import java.text.DecimalFormat;
+
+public class Formats {
+
+    public static final DecimalFormat twoDecimalPlacesPercentage = new DecimalFormat("#0.00%");
+    public static final DecimalFormat fourDecimalPlacesNumber = new DecimalFormat("#0.0000");
+}

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilder.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilder.java
@@ -1,0 +1,97 @@
+package org.owasp.benchmarkutils.score.report.html;
+
+public class HtmlStringBuilder {
+
+    private final StringBuilder sb = new StringBuilder();
+
+    //    public void append(String rawString) {
+    //        sb.append(rawString);
+    //    }
+
+    public HtmlStringBuilder beginTable() {
+        sb.append("<table>");
+
+        return this;
+    }
+
+    public HtmlStringBuilder beginTable(String cssClass) {
+        if (cssClass == null) {
+            return beginTable();
+        }
+
+        sb.append("<table class=\"").append(cssClass).append("\">");
+
+        return this;
+    }
+
+    public HtmlStringBuilder beginTr() {
+        sb.append("<tr>");
+
+        return this;
+    }
+
+    public HtmlStringBuilder beginTr(String cssClass) {
+        if (cssClass == null) {
+            return beginTr();
+        }
+
+        sb.append("<tr class=\"").append(cssClass).append("\">");
+
+        return this;
+    }
+
+    public HtmlStringBuilder th(String content) {
+        sb.append("<th>").append(content).append("</th>");
+
+        return this;
+    }
+
+    public HtmlStringBuilder th(String content, String cssClass) {
+        if (cssClass == null) {
+            return th(content);
+        }
+
+        sb.append("<th class=\"").append(cssClass).append("\">").append(content).append("</th>");
+
+        return this;
+    }
+
+    public HtmlStringBuilder endTr() {
+        sb.append("</tr>");
+
+        return this;
+    }
+
+    public HtmlStringBuilder td(String content) {
+        sb.append("<td>").append(content).append("</td>");
+
+        return this;
+    }
+
+    public HtmlStringBuilder td(String content, String cssClass) {
+        if (cssClass == null) {
+            return td(content);
+        }
+
+        sb.append("<td class=\"").append(cssClass).append("\">").append(content).append("</td>");
+
+        return this;
+    }
+
+    public HtmlStringBuilder endTable() {
+        sb.append("</table>");
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return sb.toString();
+    }
+
+    public HtmlStringBuilder p(String content) {
+        sb.append("<p>").append(content).append("</p>");
+
+        return this;
+    }
+}

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilder.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilder.java
@@ -1,12 +1,25 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.report.html;
 
 public class HtmlStringBuilder {
 
     private final StringBuilder sb = new StringBuilder();
-
-    //    public void append(String rawString) {
-    //        sb.append(rawString);
-    //    }
 
     public HtmlStringBuilder beginTable() {
         sb.append("<table>");

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTable.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTable.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.report.html;
 
 import static org.owasp.benchmarkutils.score.report.Formats.fourDecimalPlacesNumber;

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTable.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTable.java
@@ -83,9 +83,9 @@ public class OverallStatsTable {
     }
 
     private void appendRowTo(HtmlStringBuilder htmlBuilder, Tool tool) {
-        ToolResults or = tool.getOverallResults();
+        ToolResults results = tool.getOverallResults();
 
-        htmlBuilder.beginTr(cssClassFor(or));
+        htmlBuilder.beginTr(cssClassFor(results));
         htmlBuilder.td(tool.getToolNameAndVersion());
 
         if (config.mixedMode) {
@@ -96,33 +96,34 @@ public class OverallStatsTable {
 
         if (config.includePrecision) {
             htmlBuilder
-                    .td(twoDecimalPlacesPercentage.format(or.getPrecision()))
-                    .td(fourDecimalPlacesNumber.format(or.getFScore()));
+                    .td(twoDecimalPlacesPercentage.format(results.getPrecision()))
+                    .td(fourDecimalPlacesNumber.format(results.getFScore()));
         }
 
         htmlBuilder
-                .td(twoDecimalPlacesPercentage.format(or.getTruePositiveRate()))
-                .td(twoDecimalPlacesPercentage.format(or.getFalsePositiveRate()))
-                .td(twoDecimalPlacesPercentage.format(or.getOverallScore()))
+                .td(twoDecimalPlacesPercentage.format(results.getTruePositiveRate()))
+                .td(twoDecimalPlacesPercentage.format(results.getFalsePositiveRate()))
+                .td(twoDecimalPlacesPercentage.format(results.getOverallScore()))
                 .endTr();
     }
 
-    private String cssClassFor(ToolResults or) {
+    private String cssClassFor(ToolResults results) {
         String cssClass = null;
 
-        if (isDanger(or)) {
+        if (isDanger(results)) {
             cssClass = "danger";
-        } else if (isSuccess(or)) {
+        } else if (isSuccess(results)) {
             cssClass = "success";
         }
+
         return cssClass;
     }
 
-    private boolean isSuccess(ToolResults or) {
-        return or.getTruePositiveRate() > .7 && or.getFalsePositiveRate() < .3;
+    private boolean isSuccess(ToolResults results) {
+        return results.getTruePositiveRate() > .7 && results.getFalsePositiveRate() < .3;
     }
 
-    private boolean isDanger(ToolResults or) {
-        return Math.abs(or.getTruePositiveRate() - or.getFalsePositiveRate()) < .1;
+    private boolean isDanger(ToolResults results) {
+        return Math.abs(results.getTruePositiveRate() - results.getFalsePositiveRate()) < .1;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTable.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTable.java
@@ -1,0 +1,111 @@
+package org.owasp.benchmarkutils.score.report.html;
+
+import static org.owasp.benchmarkutils.score.report.Formats.fourDecimalPlacesNumber;
+import static org.owasp.benchmarkutils.score.report.Formats.twoDecimalPlacesPercentage;
+
+import java.util.Set;
+import org.owasp.benchmarkutils.score.Configuration;
+import org.owasp.benchmarkutils.score.Tool;
+import org.owasp.benchmarkutils.score.ToolResults;
+
+public class OverallStatsTable {
+
+    private final Configuration config;
+    private final String testSuite;
+
+    public OverallStatsTable(Configuration config, String testSuite) {
+        this.config = config;
+        this.testSuite = testSuite;
+    }
+
+    /**
+     * Generate the overall stats table across all the tools for the bottom of the home page.
+     *
+     * @param tools - The set of all tools being scored. Each Tool includes it's scored results.
+     * @return The HTML of the overall stats table.
+     */
+    public String generateFor(Set<Tool> tools) {
+        HtmlStringBuilder htmlBuilder = new HtmlStringBuilder();
+
+        htmlBuilder.beginTable("table");
+
+        addHeaderTo(htmlBuilder);
+
+        tools.stream()
+                .filter(tool -> !(config.showAveOnlyMode && tool.isCommercial()))
+                .forEach(tool -> appendRowTo(htmlBuilder, tool));
+
+        htmlBuilder.endTable();
+
+        htmlBuilder.p(
+                "*-Please refer to each tool's scorecard for the data used to calculate these values.");
+
+        return htmlBuilder.toString();
+    }
+
+    private void addHeaderTo(HtmlStringBuilder htmlBuilder) {
+        htmlBuilder.beginTr();
+        htmlBuilder.th("Tool");
+
+        if (config.mixedMode) {
+            htmlBuilder.th(testSuite + " Version");
+        }
+
+        htmlBuilder.th("Type");
+
+        if (config.includePrecision) {
+            htmlBuilder.th("Precision*");
+            htmlBuilder.th("F-score*");
+        }
+
+        htmlBuilder.th("${tprlabel}*");
+        htmlBuilder.th("FPR*");
+        htmlBuilder.th("Score*");
+
+        htmlBuilder.endTr();
+    }
+
+    private void appendRowTo(HtmlStringBuilder htmlBuilder, Tool tool) {
+        ToolResults or = tool.getOverallResults();
+
+        htmlBuilder.beginTr(cssClassFor(or));
+        htmlBuilder.td(tool.getToolNameAndVersion());
+
+        if (config.mixedMode) {
+            htmlBuilder.td(tool.getTestSuiteVersion());
+        }
+
+        htmlBuilder.td(tool.getToolType().name());
+
+        if (config.includePrecision) {
+            htmlBuilder
+                    .td(twoDecimalPlacesPercentage.format(or.getPrecision()))
+                    .td(fourDecimalPlacesNumber.format(or.getFScore()));
+        }
+
+        htmlBuilder
+                .td(twoDecimalPlacesPercentage.format(or.getTruePositiveRate()))
+                .td(twoDecimalPlacesPercentage.format(or.getFalsePositiveRate()))
+                .td(twoDecimalPlacesPercentage.format(or.getOverallScore()))
+                .endTr();
+    }
+
+    private String cssClassFor(ToolResults or) {
+        String cssClass = null;
+
+        if (isDanger(or)) {
+            cssClass = "danger";
+        } else if (isSuccess(or)) {
+            cssClass = "success";
+        }
+        return cssClass;
+    }
+
+    private boolean isSuccess(ToolResults or) {
+        return or.getTruePositiveRate() > .7 && or.getFalsePositiveRate() < .3;
+    }
+
+    private boolean isDanger(ToolResults or) {
+        return Math.abs(or.getTruePositiveRate() - or.getFalsePositiveRate()) < .1;
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/BenchmarkScoreTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/BenchmarkScoreTest.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2023
+ */
 package org.owasp.benchmarkutils.score;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/ConfigurationTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/ConfigurationTest.java
@@ -13,7 +13,7 @@
  * PURPOSE. See the GNU General Public License for more details.
  *
  * @author Sascha Knoop
- * @created 2022
+ * @created 2023
  */
 package org.owasp.benchmarkutils.score;
 

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ConfigurationBuilder.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ConfigurationBuilder.java
@@ -1,0 +1,146 @@
+package org.owasp.benchmarkutils.score.builder;
+
+import static java.io.File.createTempFile;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.owasp.benchmarkutils.score.Configuration;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+public class ConfigurationBuilder {
+
+    private String expectedResultsFileName;
+    private String resultsFileOrDirName;
+    private String focus;
+    private boolean anonymousMode;
+    private boolean includePrecision;
+    private boolean showAveOnlyMode;
+    private boolean mixedMode;
+    private String cweCategoryName;
+    private String tprLabel;
+    private boolean includeProjectLink;
+
+    private ConfigurationBuilder() {
+        Configuration defaultConfig = Configuration.fromDefaultConfig();
+
+        this.expectedResultsFileName = defaultConfig.expectedResultsFileName;
+        this.resultsFileOrDirName = defaultConfig.resultsFileOrDirName;
+        this.focus = defaultConfig.focus;
+        this.anonymousMode = defaultConfig.anonymousMode;
+        this.includePrecision = defaultConfig.includePrecision;
+        this.showAveOnlyMode = defaultConfig.showAveOnlyMode;
+        this.mixedMode = defaultConfig.mixedMode;
+        this.cweCategoryName = defaultConfig.cweCategoryName;
+        this.tprLabel = defaultConfig.tprLabel;
+        this.includeProjectLink = defaultConfig.includeProjectLink;
+    }
+
+    public static ConfigurationBuilder builder() {
+        return new ConfigurationBuilder();
+    }
+
+    public ConfigurationBuilder setExpectedResultsFileName(String expectedResultsFileName) {
+        this.expectedResultsFileName = expectedResultsFileName;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setResultsFileOrDirName(String resultsFileOrDirName) {
+        this.resultsFileOrDirName = resultsFileOrDirName;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setFocus(String focus) {
+        this.focus = focus;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setAnonymousMode(boolean anonymousMode) {
+        this.anonymousMode = anonymousMode;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setIncludePrecision(boolean includePrecision) {
+        this.includePrecision = includePrecision;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setShowAveOnlyMode(boolean showAveOnlyMode) {
+        this.showAveOnlyMode = showAveOnlyMode;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setMixedMode(boolean mixedMode) {
+        this.mixedMode = mixedMode;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setCweCategoryName(String cweCategoryName) {
+        this.cweCategoryName = cweCategoryName;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setTprLabel(String tprLabel) {
+        this.tprLabel = tprLabel;
+
+        return this;
+    }
+
+    public ConfigurationBuilder setIncludeProjectLink(boolean includeProjectLink) {
+        this.includeProjectLink = includeProjectLink;
+
+        return this;
+    }
+
+    public Configuration build() {
+        try {
+            Map<String, Object> testConfig = new HashMap<>();
+
+            testConfig.put("expectedresults", expectedResultsFileName);
+            testConfig.put("resultsfileordir", resultsFileOrDirName);
+            testConfig.put("focustool", focus);
+            testConfig.put("anonymousmode", anonymousMode);
+            testConfig.put("averageonlymode", showAveOnlyMode);
+            testConfig.put("mixedmode", mixedMode);
+            testConfig.put("cwecategoryname", cweCategoryName);
+            testConfig.put("tprlabel", tprLabel);
+            testConfig.put("includeprojectlink", includeProjectLink);
+            testConfig.put("includeprecision", includePrecision);
+
+            return Configuration.fromFile(writeTempConfig(testConfig).getAbsolutePath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static File writeTempConfig(Map<String, Object> testConfig) throws IOException {
+        Yaml yaml = getYaml();
+
+        File tempConfigFile = createTempFile("config", ".yaml");
+
+        try (FileWriter writer = new FileWriter(tempConfigFile)) {
+            yaml.dump(testConfig, writer);
+        }
+        return tempConfigFile;
+    }
+
+    private static Yaml getYaml() {
+        final DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+
+        Yaml yaml = new Yaml(options);
+        return yaml;
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ConfigurationBuilder.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ConfigurationBuilder.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.builder;
 
 import static java.io.File.createTempFile;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/TestSuiteResultsBuilder.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/TestSuiteResultsBuilder.java
@@ -1,0 +1,38 @@
+package org.owasp.benchmarkutils.score.builder;
+
+import org.owasp.benchmarkutils.score.TestSuiteResults;
+
+public class TestSuiteResultsBuilder {
+
+    private String toolname = "";
+    private boolean isCommercial = false;
+    private TestSuiteResults.ToolType toolType = TestSuiteResults.ToolType.SAST;
+
+    private TestSuiteResultsBuilder() {}
+
+    public static TestSuiteResultsBuilder builder() {
+        return new TestSuiteResultsBuilder();
+    }
+
+    public TestSuiteResultsBuilder setToolname(String toolname) {
+        this.toolname = toolname;
+
+        return this;
+    }
+
+    public TestSuiteResultsBuilder setIsCommercial(boolean isCommercial) {
+        this.isCommercial = isCommercial;
+
+        return this;
+    }
+
+    public TestSuiteResultsBuilder setToolType(TestSuiteResults.ToolType toolType) {
+        this.toolType = toolType;
+
+        return this;
+    }
+
+    public TestSuiteResults build() {
+        return new TestSuiteResults(toolname, isCommercial, toolType);
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/TestSuiteResultsBuilder.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/TestSuiteResultsBuilder.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.builder;
 
 import org.owasp.benchmarkutils.score.TestSuiteResults;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ToolBuilder.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ToolBuilder.java
@@ -1,0 +1,64 @@
+package org.owasp.benchmarkutils.score.builder;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.owasp.benchmarkutils.score.TP_FN_TN_FP_Counts;
+import org.owasp.benchmarkutils.score.TestSuiteResults;
+import org.owasp.benchmarkutils.score.Tool;
+import org.owasp.benchmarkutils.score.ToolResults;
+
+public class ToolBuilder {
+
+    private TestSuiteResults testSuiteResults = TestSuiteResultsBuilder.builder().build();
+    private Map<String, TP_FN_TN_FP_Counts> scores = new HashMap<>();
+    private ToolResults toolResults = new ToolResults();
+    private String actualCsvResultFileName = "";
+    private boolean isCommercial = false;
+
+    private ToolBuilder() {}
+
+    public static ToolBuilder builder() {
+        return new ToolBuilder();
+    }
+
+    public ToolBuilder setTestSuiteResults(TestSuiteResults testSuiteResults) {
+        this.testSuiteResults = testSuiteResults;
+
+        return this;
+    }
+
+    public ToolBuilder setScores(Map<String, TP_FN_TN_FP_Counts> scores) {
+        this.scores = scores;
+
+        return this;
+    }
+
+    public ToolBuilder setScore(String key, TP_FN_TN_FP_Counts value) {
+        this.scores.put(key, value);
+
+        return this;
+    }
+
+    public ToolBuilder setToolResults(ToolResults toolResults) {
+        this.toolResults = toolResults;
+
+        return this;
+    }
+
+    public ToolBuilder setActualCsvResultFileName(String actualCsvResultFileName) {
+        this.actualCsvResultFileName = actualCsvResultFileName;
+
+        return this;
+    }
+
+    public ToolBuilder setIsCommercial(boolean isCommercial) {
+        this.isCommercial = isCommercial;
+
+        return this;
+    }
+
+    public Tool build() {
+        return new Tool(
+                testSuiteResults, scores, toolResults, actualCsvResultFileName, isCommercial);
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ToolBuilder.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/builder/ToolBuilder.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.builder;
 
 import java.util.HashMap;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/FormatsTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/FormatsTest.java
@@ -1,0 +1,20 @@
+package org.owasp.benchmarkutils.score.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.owasp.benchmarkutils.score.report.Formats.fourDecimalPlacesNumber;
+import static org.owasp.benchmarkutils.score.report.Formats.twoDecimalPlacesPercentage;
+
+import org.junit.jupiter.api.Test;
+
+class FormatsTest {
+
+    @Test
+    void hasFormatterForTwoDecimalPlacesPercentage() {
+        assertEquals("1234.57%", twoDecimalPlacesPercentage.format(12.345678));
+    }
+
+    @Test
+    void hasFormatterForFourDecimalPlaces() {
+        assertEquals("12.3457", fourDecimalPlacesNumber.format(12.345678));
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/FormatsTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/FormatsTest.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.report;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilderTest.java
@@ -1,0 +1,69 @@
+package org.owasp.benchmarkutils.score.report.html;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class HtmlStringBuilderTest {
+
+    @Test
+    void createsTable() {
+        HtmlStringBuilder sb = new HtmlStringBuilder();
+
+        String table =
+                sb.beginTable("table-class")
+                        .beginTr("header")
+                        .th("first th", "some-th-class")
+                        .th("second th")
+                        .endTr()
+                        .beginTr()
+                        .td("first td", "some-td-class")
+                        .td("second td")
+                        .endTr()
+                        .endTable()
+                        .beginTable()
+                        .endTable()
+                        .toString();
+
+        assertEquals(
+                "<table class=\"table-class\">"
+                        + "<tr class=\"header\">"
+                        + "<th class=\"some-th-class\">first th</th>"
+                        + "<th>second th</th>"
+                        + "</tr>"
+                        + "<tr>"
+                        + "<td class=\"some-td-class\">first td</td>"
+                        + "<td>second td</td>"
+                        + "</tr>"
+                        + "</table>"
+                        + "<table>"
+                        + "</table>",
+                table);
+    }
+
+    @Test
+    void treatsNullCssClassAsNoneForTables() {
+        HtmlStringBuilder sb = new HtmlStringBuilder();
+
+        String table =
+                sb.beginTable(null)
+                        .beginTr(null)
+                        .th("th", null)
+                        .td("td", null)
+                        .endTr()
+                        .endTable()
+                        .toString();
+
+        assertEquals(
+                "<table>" + "<tr>" + "<th>th</th>" + "<td>td</td>" + "</tr>" + "</table>", table);
+    }
+
+    @Test
+    void createsParagraph() {
+        HtmlStringBuilder sb = new HtmlStringBuilder();
+
+        sb.p("Some paragraph");
+
+        assertEquals("<p>Some paragraph</p>", sb.toString());
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilderTest.java
@@ -72,7 +72,7 @@ class HtmlStringBuilderTest {
                         .toString();
 
         assertEquals(
-                "<table>" + "<tr>" + "<th>th</th>" + "<td>td</td>" + "</tr>" + "</table>", table);
+                "<table><tr><th>th</th><td>td</td></tr></table>", table);
     }
 
     @Test

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/HtmlStringBuilderTest.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.report.html;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTableTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTableTest.java
@@ -1,3 +1,20 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
 package org.owasp.benchmarkutils.score.report.html;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTableTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/OverallStatsTableTest.java
@@ -1,0 +1,244 @@
+package org.owasp.benchmarkutils.score.report.html;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.owasp.benchmarkutils.score.BenchmarkScore;
+import org.owasp.benchmarkutils.score.Configuration;
+import org.owasp.benchmarkutils.score.TestSuiteResults;
+import org.owasp.benchmarkutils.score.TestSuiteResults.ToolType;
+import org.owasp.benchmarkutils.score.Tool;
+import org.owasp.benchmarkutils.score.ToolResults;
+import org.owasp.benchmarkutils.score.builder.ConfigurationBuilder;
+import org.owasp.benchmarkutils.score.builder.ToolBuilder;
+
+class OverallStatsTableTest {
+
+    @BeforeEach
+    void setUp() {
+        BenchmarkScore.config = Configuration.fromDefaultConfig();
+    }
+
+    @Test
+    void createsResultTableForTools() {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(false)
+                        .setMixedMode(false)
+                        .setIncludePrecision(false)
+                        .build();
+
+        Tool firstTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(testSuiteResults("Tool A", "1.0", true, ToolType.SAST))
+                        .setToolResults(toolResults(0.7, 0.5))
+                        .setIsCommercial(true)
+                        .build();
+        Tool secondTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(
+                                testSuiteResults("Tool B", "2.0", false, ToolType.DAST))
+                        .setToolResults(toolResults(0.8, 0.6))
+                        .build();
+
+        OverallStatsTable table = new OverallStatsTable(config, "Benchmark");
+
+        String actual = table.generateFor(asSet(firstTool, secondTool));
+
+        assertTrue(
+                actual.startsWith(
+                        "<table class=\"table\"><tr><th>Tool</th><th>Type</th>"
+                                + "<th>${tprlabel}*</th><th>FPR*</th><th>Score*</th></tr>"));
+        assertTrue(
+                actual.contains(
+                        "<tr><td>Tool A v1.0</td><td>SAST</td><td>70.00%</td>"
+                                + "<td>50.00%</td><td>20.00%</td></tr>"));
+        assertTrue(
+                actual.contains(
+                        "<tr><td>Tool B v2.0</td><td>DAST</td><td>80.00%</td>"
+                                + "<td>60.00%</td><td>20.00%</td></tr>"));
+        assertTrue(
+                actual.endsWith(
+                        "</table><p>*-Please refer to each tool's scorecard for "
+                                + "the data used to calculate these values.</p>"));
+    }
+
+    private TestSuiteResults testSuiteResults(
+            String name, String version, boolean isCommercial, ToolType type) {
+        TestSuiteResults results = new TestSuiteResults(name, isCommercial, type);
+
+        results.setToolVersion(version);
+
+        return results;
+    }
+
+    private ToolResults toolResults(double tpRate, double fpRate) {
+        ToolResults results = new ToolResults();
+
+        results.setTruePositiveRate(tpRate);
+        results.setFalsePositiveRate(fpRate);
+
+        return results;
+    }
+
+    private Set<Tool> asSet(Tool... tools) {
+        return Arrays.stream(tools).collect(Collectors.toSet());
+    }
+
+    @Test
+    void showsSuccessColumns() {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(false)
+                        .setMixedMode(false)
+                        .setIncludePrecision(false)
+                        .build();
+
+        Tool firstTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(
+                                testSuiteResults("Tool A", "1.0", false, ToolType.SAST))
+                        .setToolResults(toolResults(0.8, 0.1))
+                        .build();
+
+        OverallStatsTable table = new OverallStatsTable(config, "Benchmark");
+
+        String actual = table.generateFor(asSet(firstTool));
+
+        assertTrue(
+                actual.contains(
+                        "<tr class=\"success\"><td>Tool A v1.0</td><td>SAST</td>"
+                                + "<td>80.00%</td><td>10.00%</td><td>70.00%</td></tr>"));
+    }
+
+    @Test
+    void showsDangerColumns() {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(false)
+                        .setMixedMode(false)
+                        .setIncludePrecision(false)
+                        .build();
+
+        Tool firstTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(
+                                testSuiteResults("Tool A", "1.0", false, ToolType.SAST))
+                        .setToolResults(toolResults(0.2, 0.2))
+                        .build();
+
+        OverallStatsTable table = new OverallStatsTable(config, "Benchmark");
+
+        String actual = table.generateFor(asSet(firstTool));
+
+        assertTrue(
+                actual.contains(
+                        "<tr class=\"danger\"><td>Tool A v1.0</td><td>SAST</td>"
+                                + "<td>20.00%</td><td>20.00%</td><td>0.00%</td></tr>"));
+    }
+
+    @Test
+    void hidesCommercialToolsInAverageMode() {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(true)
+                        .setMixedMode(false)
+                        .setIncludePrecision(false)
+                        .build();
+
+        Tool firstTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(testSuiteResults("Tool A", "", true, ToolType.SAST))
+                        .setIsCommercial(true)
+                        .build();
+        Tool secondTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(testSuiteResults("Tool B", "", false, ToolType.SAST))
+                        .setToolResults(toolResults(0, 0))
+                        .build();
+
+        OverallStatsTable table = new OverallStatsTable(config, "Benchmark");
+
+        String actual = table.generateFor(asSet(firstTool, secondTool));
+
+        assertFalse(actual.contains("Tool A"));
+        assertTrue(actual.contains("Tool B"));
+    }
+
+    @Test
+    void createsResultTableInMixedMode() {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(false)
+                        .setMixedMode(true)
+                        .setIncludePrecision(false)
+                        .build();
+
+        TestSuiteResults firstToolResults = testSuiteResults("Tool A", "1.0", true, ToolType.SAST);
+        firstToolResults.setTestSuiteVersion("1.2");
+        Tool firstTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(firstToolResults)
+                        .setToolResults(toolResults(0.7, 0.5))
+                        .setIsCommercial(true)
+                        .build();
+        TestSuiteResults secondToolResults =
+                testSuiteResults("Tool B", "2.0", false, ToolType.DAST);
+        secondToolResults.setTestSuiteVersion("1.3");
+        Tool secondTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(secondToolResults)
+                        .setToolResults(toolResults(0.8, 0.6))
+                        .build();
+
+        OverallStatsTable table = new OverallStatsTable(config, "Benchmark");
+
+        String actual = table.generateFor(asSet(firstTool, secondTool));
+
+        assertTrue(actual.contains("<th>Benchmark Version</th>"));
+        assertTrue(actual.contains("<td>Tool A v1.0</td><td>1.2</td>"));
+        assertTrue(actual.contains("<td>Tool B v2.0</td><td>1.3</td>"));
+    }
+
+    @Test
+    void createsResultTableWithPrecision() {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(false)
+                        .setMixedMode(false)
+                        .setIncludePrecision(true)
+                        .build();
+
+        ToolResults firstToolResults = toolResults(0.7, 0.5);
+        firstToolResults.setPrecision(0.12345);
+        Tool firstTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(testSuiteResults("Tool A", "1.0", true, ToolType.SAST))
+                        .setToolResults(firstToolResults)
+                        .setIsCommercial(true)
+                        .build();
+        ToolResults secondToolResults = toolResults(0.8, 0.6);
+        secondToolResults.setPrecision(0.33333);
+        Tool secondTool =
+                ToolBuilder.builder()
+                        .setTestSuiteResults(
+                                testSuiteResults("Tool B", "2.0", false, ToolType.DAST))
+                        .setToolResults(secondToolResults)
+                        .build();
+
+        OverallStatsTable table = new OverallStatsTable(config, "Benchmark");
+
+        String actual = table.generateFor(asSet(firstTool, secondTool));
+
+        assertTrue(actual.contains("<th>Precision*</th><th>F-score*</th>"));
+        assertTrue(
+                actual.contains("<td>Tool A v1.0</td><td>SAST</td><td>12.35%</td><td>0.2099</td>"));
+        assertTrue(
+                actual.contains("<td>Tool B v2.0</td><td>DAST</td><td>33.33%</td><td>0.4706</td>"));
+    }
+}


### PR DESCRIPTION
Currently, the `BenchmarkScore` class is a mix of Maven stuff, delegations, calculations and HTML. Moreover, HTML code exists in some other classes. I'd like to extract all the HTML stuff to its own sub package and just call it, so it's clear what code belongs to the final report.

This is the first PR that picks one table - in that case the overall stats table - and extract it to its own class without access to any static/global variable.