### PR TITLE
Add reader and tests for SAST Precaution

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/PrecautionReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/PrecautionReader.java
@@ -1,0 +1,61 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Eric Brown
+ * @created 2024
+ */
+package org.owasp.benchmarkutils.score.parsers;
+
+import static java.lang.Integer.parseInt;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PrecautionReader extends SarifReader {
+    private final String CWE_PREFIX = "external/cwe/cwe-";
+    private final int CWE_PREFIX_LENGTH = CWE_PREFIX.length();
+
+    @Override
+    protected String expectedSarifToolName() {
+        return "Precaution";
+    }
+
+    @Override
+    protected boolean isCommercial() {
+        return false;
+    }
+
+    @Override
+    protected Map<String, Integer> ruleCweMappings(JSONArray rules) {
+        Map<String, Integer> mappings = new HashMap<>();
+
+        for (int i = 0; i < rules.length(); i++) {
+            JSONObject rule = rules.getJSONObject(i);
+            JSONArray tags = rule.getJSONObject("properties").getJSONArray("tags");
+
+            for (int j = 0; j < tags.length(); j++) {
+                String tag = tags.getString(j);
+
+                if (tag.startsWith(CWE_PREFIX)) {
+                    int cwe = parseInt(tag.substring(CWE_PREFIX_LENGTH));
+                    mappings.put(rule.getString("id"), cwe);
+                }
+            }
+        }
+
+        return mappings;
+    }
+}

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
@@ -82,6 +82,7 @@ public abstract class Reader {
                 new NJSScanReader(),
                 new NoisyCricketReader(),
                 new ParasoftReader(),
+                new PrecautionReader(),
                 new PMDReader(),
                 new QualysWASReader(),
                 new Rapid7Reader(),

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/PrecautionReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/PrecautionReaderTest.java
@@ -1,0 +1,58 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Eric Brown
+ * @created 2024
+ */
+package org.owasp.benchmarkutils.score.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.owasp.benchmarkutils.score.BenchmarkScore;
+import org.owasp.benchmarkutils.score.CweNumber;
+import org.owasp.benchmarkutils.score.ResultFile;
+import org.owasp.benchmarkutils.score.TestHelper;
+import org.owasp.benchmarkutils.score.TestSuiteResults;
+
+class PrecautionReaderTest extends ReaderTestBase {
+
+    private ResultFile resultFile;
+
+    @BeforeEach
+    void setUp() {
+        resultFile = TestHelper.resultFileOf("testfiles/Benchmark_Precaution.sarif");
+        BenchmarkScore.TESTCASENAME = "BenchmarkTest";
+    }
+
+    @Test
+    public void onlyPrecautionReportsCanReadAsTrue() {
+        assertOnlyMatcherClassIs(this.resultFile, PrecautionReader.class);
+    }
+
+    @Test
+    void readerHandlesGivenResultFile() throws Exception {
+        PrecautionReader reader = new PrecautionReader();
+        TestSuiteResults result = reader.parse(resultFile);
+
+        assertEquals(TestSuiteResults.ToolType.SAST, result.getToolType());
+        assertFalse(result.isCommercial());
+        assertEquals("Precaution", result.getToolName());
+        assertEquals("0.5.0", result.getToolVersion());
+        assertEquals(1, result.getTotalResults());
+        assertEquals(CweNumber.WEAK_HASH_ALGO, result.get(73).get(0).getCWE());
+    }
+}

--- a/plugin/src/test/resources/testfiles/Benchmark_Precaution.sarif
+++ b/plugin/src/test/resources/testfiles/Benchmark_Precaution.sarif
@@ -1,0 +1,117 @@
+{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Precaution",
+          "organization": "Secure Sauce",
+          "rules": [
+            {
+              "id": "JAV002",
+              "help": {
+                "text": "The Java `MessageDigest` class provides a number of options for algorithms\nto hash data. However, some of the hash algorithms are insecure and should\nnot be used. These insecure hash algorithms include `MD5` and `SHA-1`.\n\nThe MD5 hash algorithm is a cryptographic hash function that was designed in\nthe early 1990s. MD5 is no longer considered secure, and passwords hashed\nwith MD5 can be easily cracked by attackers.\n\nThe SHA-1 hash algorithm is also a cryptographic hash function that was\ndesigned in the early 1990s. SHA-1 is no longer considered secure, and\npasswords hashed with SHA-1 can be easily cracked by attackers.\n\n## Example\n\n```java\nimport java.security.*;\n\npublic class MessageDigestMD5 {\n    public static void main(String[] args) {\n        try {\n            MessageDigest md = MessageDigest.getInstance(\"MD5\");\n        } catch (NoSuchAlgorithmException e) {\n            System.err.println(\"MD5 hashing algorithm not available.\");\n        }\n    }\n}\n```\n\n## Remediation\n\nThe recommendation is to swap the insecure hashing method to one of the more\nsecure alternatives, `SHA-256` or `SHA-512`.\n\n```java\nimport java.security.*;\n\npublic class MessageDigestSHA256 {\n    public static void main(String[] args) {\n        try {\n            MessageDigest md = MessageDigest.getInstance(\"SHA-256\");\n        } catch (NoSuchAlgorithmException e) {\n            System.err.println(\"SHA-256 hashing algorithm not available.\");\n        }\n    }\n}\n```\n\n## See also\n\n- [MessageDigest (Java SE & JDK)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/MessageDigest.html#getInstance(java.lang.String))\n- [CWE-328: Use of Weak Hash](https://cwe.mitre.org/data/definitions/328.html)\n- [NIST Policy on Hash Functions](https://csrc.nist.gov/projects/hash-functions)\n\n_New in version 0.5.0_\n\n",
+                "markdown": "The Java `MessageDigest` class provides a number of options for algorithms\nto hash data. However, some of the hash algorithms are insecure and should\nnot be used. These insecure hash algorithms include `MD5` and `SHA-1`.\n\nThe MD5 hash algorithm is a cryptographic hash function that was designed in\nthe early 1990s. MD5 is no longer considered secure, and passwords hashed\nwith MD5 can be easily cracked by attackers.\n\nThe SHA-1 hash algorithm is also a cryptographic hash function that was\ndesigned in the early 1990s. SHA-1 is no longer considered secure, and\npasswords hashed with SHA-1 can be easily cracked by attackers.\n\n## Example\n\n```java\nimport java.security.*;\n\npublic class MessageDigestMD5 {\n    public static void main(String[] args) {\n        try {\n            MessageDigest md = MessageDigest.getInstance(\"MD5\");\n        } catch (NoSuchAlgorithmException e) {\n            System.err.println(\"MD5 hashing algorithm not available.\");\n        }\n    }\n}\n```\n\n## Remediation\n\nThe recommendation is to swap the insecure hashing method to one of the more\nsecure alternatives, `SHA-256` or `SHA-512`.\n\n```java\nimport java.security.*;\n\npublic class MessageDigestSHA256 {\n    public static void main(String[] args) {\n        try {\n            MessageDigest md = MessageDigest.getInstance(\"SHA-256\");\n        } catch (NoSuchAlgorithmException e) {\n            System.err.println(\"SHA-256 hashing algorithm not available.\");\n        }\n    }\n}\n```\n\n## See also\n\n- [MessageDigest (Java SE & JDK)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/MessageDigest.html#getInstance(java.lang.String))\n- [CWE-328: Use of Weak Hash](https://cwe.mitre.org/data/definitions/328.html)\n- [NIST Policy on Hash Functions](https://csrc.nist.gov/projects/hash-functions)\n\n_New in version 0.5.0_\n\n"
+              },
+              "name": "MessageDigestWeakHash",
+              "properties": {
+                "tags": [
+                  "security",
+                  "external/cwe/cwe-328"
+                ],
+                "security-severity": "8.0"
+              },
+              "helpUri": "https://docs.securesauce.dev/rules/JAV002",
+              "messageStrings": {
+                "default": {
+                  "text": "The hash function '{0}' is vulnerable to collision and pre-image attacks."
+                }
+              },
+              "shortDescription": {
+                "text": "Reversible One Way Hash in java.security Package"
+              }
+            }
+          ],
+          "downloadUri": "https://pypi.org/project/precli/#files",
+          "fullDescription": {
+            "text": "Static analysis security tool command line"
+          },
+          "informationUri": "https://github.com/securesauce/precli",
+          "semanticVersion": "0.5.0",
+          "shortDescription": {
+            "text": "Static analysis security tool command line"
+          }
+        }
+      },
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "endTimeUtc": "2024-04-16T22:00:01Z"
+        }
+      ],
+      "results": [
+        {
+          "message": {
+            "text": "The hash function 'MD5' is vulnerable to collision and pre-image attacks."
+          },
+          "fixes": [
+            {
+              "description": {
+                "text": "For cryptographic purposes, use a hash length of at least 256-bits with hashes such as SHA-256."
+              },
+              "artifactChanges": [
+                {
+                  "replacements": [
+                    {
+                      "deletedRegion": {
+                        "endColumn": 91,
+                        "endLine": 87,
+                        "startColumn": 86,
+                        "startLine": 87
+                      },
+                      "insertedContent": {
+                        "text": "\"SHA-256\""
+                      }
+                    }
+                  ],
+                  "artifactLocation": {
+                    "uri": "BenchmarkJava/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00073.java"
+                  }
+                }
+              ]
+            }
+          ],
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "region": {
+                  "snippet": {
+                    "text": "            java.security.MessageDigest md = java.security.MessageDigest.getInstance(\"MD5\");\n"
+                  },
+                  "endColumn": 91,
+                  "endLine": 87,
+                  "startColumn": 86,
+                  "startLine": 87
+                },
+                "artifactLocation": {
+                  "uri": "BenchmarkJava/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00073.java"
+                },
+                "contextRegion": {
+                  "snippet": {
+                    "text": "        try {\n            java.security.MessageDigest md = java.security.MessageDigest.getInstance(\"MD5\");\n            byte[] input = {(byte) '?'};\n"
+                  },
+                  "endLine": 88,
+                  "startLine": 86
+                }
+              }
+            }
+          ],
+          "ruleId": "JAV002",
+          "ruleIndex": 0
+        }
+      ]
+    }
+  ],
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json"
+}


### PR DESCRIPTION
This change adds Precaution to the list of supported SASTs. Precaution can render its output as SARIF so it extends the SarifReader.

Included are a test case and example SARIF output file as a result of scanning BenchmarkTest00073.java in BenchmarkJava.

https://github.com/securesauce/precli