### PR TITLE
Checkmarx results parser - Normalize paths

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxESReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxESReader.java
@@ -141,14 +141,14 @@ public class CheckmarxESReader extends Reader {
             // get the testcase number
             // Try get testcase from the first node
             JSONArray nodes = result.getJSONArray("Nodes");
-            String resultFileName = nodes.getJSONObject(0).getString("FileName");
-            String testcaseName = resultFileName.substring(resultFileName.lastIndexOf('\\') + 1);
+            String resultFileName = nodes.getJSONObject(0).getString("FileName").replace("\\", "/");
+            String testcaseName = resultFileName.substring(resultFileName.lastIndexOf('/') + 1);
             if (testcaseName.startsWith(BenchmarkScore.TESTCASENAME)) {
                 tcr.setNumber(testNumber(testcaseName));
                 return tcr;
             } else {
-                resultFileName = nodes.getJSONObject(nodes.length() - 1).getString("FileName");
-                testcaseName = resultFileName.substring(resultFileName.lastIndexOf('\\') + 1);
+                resultFileName = nodes.getJSONObject(nodes.length() - 1).getString("FileName").replace("\\", "/");
+                testcaseName = resultFileName.substring(resultFileName.lastIndexOf('/') + 1);
                 if (testcaseName.startsWith(BenchmarkScore.TESTCASENAME)) {
                     tcr.setNumber(testNumber(testcaseName));
                     return tcr;

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxESReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxESReader.java
@@ -147,7 +147,10 @@ public class CheckmarxESReader extends Reader {
                 tcr.setNumber(testNumber(testcaseName));
                 return tcr;
             } else {
-                resultFileName = nodes.getJSONObject(nodes.length() - 1).getString("FileName").replace("\\", "/");
+                resultFileName =
+                        nodes.getJSONObject(nodes.length() - 1)
+                                .getString("FileName")
+                                .replace("\\", "/");
                 testcaseName = resultFileName.substring(resultFileName.lastIndexOf('/') + 1);
                 if (testcaseName.startsWith(BenchmarkScore.TESTCASENAME)) {
                     tcr.setNumber(testNumber(testcaseName));


### PR DESCRIPTION
Normalize SAST results file path in order to compute OWASP scorecard on Windows or Linux base scans .
