### PR TITLE
Move tool scorecard generation to separate class

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/Tool.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/Tool.java
@@ -17,14 +17,8 @@
  */
 package org.owasp.benchmarkutils.score;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Map;
 import org.owasp.benchmarkutils.score.TestSuiteResults.ToolType;
-import org.owasp.benchmarkutils.score.report.ScatterTools;
-import org.owasp.benchmarkutils.score.report.ToolBarChart;
-import org.owasp.benchmarkutils.score.report.ToolReport;
 
 public class Tool implements Comparable<Tool> {
 
@@ -44,9 +38,6 @@ public class Tool implements Comparable<Tool> {
     private final ToolResults overallResults; // The scored results for this tool.
     private final String actualResultsFileName; // Name of this tool's .csv computed results file
 
-    // The name of the file that contains this tool's scorecard, without the file extension
-    private String scorecardFilename = null;
-
     public Tool(
             TestSuiteResults actualResults,
             Map<String, TP_FN_TN_FP_Counts> scores,
@@ -64,70 +55,6 @@ public class Tool implements Comparable<Tool> {
         this.actualResults = actualResults;
         this.overallResults = toolResults;
         this.actualResultsFileName = actualCSVResultsFileName;
-
-        this.scorecardFilename =
-                BenchmarkScore.TESTSUITE
-                        + " v"
-                        + this.testSuiteVersion
-                        + " Scorecard for "
-                        + this.toolNameAndVersion;
-        this.scorecardFilename = scorecardFilename.replace(' ', '_');
-    }
-
-    void generateScorecard(Map<String, CategoryResults> overallAveToolResults, File scoreCardDir) {
-
-        // Generate the HTML scorecard for this tool
-        if (!(BenchmarkScore.config.showAveOnlyMode && this.isCommercial)) {
-
-            // Generate and save the Scatter Chart for this tool
-            String shortTitle =
-                    BenchmarkScore.TESTSUITE
-                            + " v"
-                            + this.testSuiteVersion
-                            + " Scorecard for "
-                            + this.toolName;
-            ScatterTools graph = new ScatterTools(shortTitle, 800, this.overallResults);
-
-            File img = new File(scoreCardDir, scorecardFilename + ".png");
-            try {
-                graph.writeChartToFile(img, 800);
-            } catch (IOException e) {
-                System.out.println("Error saving tool Scatter chart to disk!");
-                e.printStackTrace();
-            }
-
-            // Generate the Precision/Recall charts for this tool
-            ToolBarChart.generateComparisonCharts(this, overallAveToolResults, scoreCardDir);
-
-            String reportPath =
-                    scoreCardDir.getAbsolutePath() + File.separator + scorecardFilename + ".html";
-            String fullTitle =
-                    BenchmarkScore.fullTestSuiteName(BenchmarkScore.TESTSUITE)
-                            + " Scorecard for "
-                            + this.toolNameAndVersion;
-            // If not in anonymous mode OR the tool is not commercial, add the type at the end of
-            // the name. It's not added to anonymous commercial tools, because it would be
-            // redundant.
-            if (!BenchmarkScore.config.anonymousMode || !this.isCommercial) {
-                fullTitle += " (" + this.toolType + ")";
-            }
-
-            String reportHtml;
-            try {
-                reportHtml =
-                        ToolReport.generateHtml(
-                                this,
-                                fullTitle,
-                                img,
-                                this.actualResultsFileName,
-                                overallAveToolResults);
-                Files.write(new File(reportPath).toPath(), reportHtml.getBytes());
-                System.out.println("Scorecard written to: " + reportPath);
-            } catch (Exception e) {
-                System.out.println("Error creating and/or saving tool HTML scorecard!");
-                e.printStackTrace();
-            }
-        }
     }
 
     /**
@@ -155,13 +82,17 @@ public class Tool implements Comparable<Tool> {
         return this.testSuiteVersion;
     }
 
-    /**
-     * Gets the name of the file that contains the generated HTML scorecard for this tool.
-     *
-     * @return Name of the file (without any path information and the file extension)
-     */
-    public String getScorecardFilename() {
-        return this.scorecardFilename;
+    //    /**
+    //     * Gets the name of the file that contains the generated HTML scorecard for this tool.
+    //     *
+    //     * @return Name of the file (without any path information and the file extension)
+    //     */
+    //    public String getScorecardFilename() {
+    //        return this.scorecardFilename;
+    //    }
+
+    public String getActualResultsFileName() {
+        return actualResultsFileName;
     }
 
     /**

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/Tool.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/Tool.java
@@ -82,15 +82,6 @@ public class Tool implements Comparable<Tool> {
         return this.testSuiteVersion;
     }
 
-    //    /**
-    //     * Gets the name of the file that contains the generated HTML scorecard for this tool.
-    //     *
-    //     * @return Name of the file (without any path information and the file extension)
-    //     */
-    //    public String getScorecardFilename() {
-    //        return this.scorecardFilename;
-    //    }
-
     public String getActualResultsFileName() {
         return actualResultsFileName;
     }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/ToolBarChart.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/ToolBarChart.java
@@ -36,18 +36,27 @@ import org.owasp.benchmarkutils.helpers.Categories;
 import org.owasp.benchmarkutils.score.BenchmarkScore;
 import org.owasp.benchmarkutils.score.CategoryResults;
 import org.owasp.benchmarkutils.score.Tool;
+import org.owasp.benchmarkutils.score.report.html.ToolBarChartProvider;
 
-public class ToolBarChart extends ScatterPlot {
+public class ToolBarChart extends ScatterPlot implements ToolBarChartProvider {
 
     private static final Color BLUECOLUMN = Color.decode("#4572a7"); // Blue
     private static final Color PURPLECOLUMN = Color.decode("#7851a9"); // Royal purple
+
+    private final Map<String, CategoryResults> overallAveToolResults;
+    private final File scoreCardDir;
 
     enum BarChartType {
         Precision,
         Recall
     }
 
-    public static void initializePlot(
+    public ToolBarChart(Map<String, CategoryResults> overallAveToolResults, File scoreCardDir) {
+        this.overallAveToolResults = overallAveToolResults;
+        this.scoreCardDir = scoreCardDir;
+    }
+
+    private static void initializePlot(
             JFreeChart chart, DefaultCategoryDataset dataset, Color toolColor) {
         CategoryPlot xyplot = chart.getCategoryPlot();
         CategoryItemRenderer renderer = xyplot.getRendererForDataset(dataset);
@@ -92,9 +101,8 @@ public class ToolBarChart extends ScatterPlot {
      *     to.
      * @param type - The Type of BarChart to create.
      * @param scoreCardDir - The directory to write the created Chart file into.
-     * @return The name of the file created (with no path information).
      */
-    public static String createBarChart(
+    private static void createBarChart(
             Tool tool, DefaultCategoryDataset dataset, BarChartType type, File scoreCardDir) {
 
         JFreeChart chart =
@@ -128,9 +136,7 @@ public class ToolBarChart extends ScatterPlot {
         } catch (IOException e) {
             System.out.println("Error writing bar chart to target file.");
             e.printStackTrace();
-            return null;
         }
-        return fileToCreate;
     }
 
     /**
@@ -143,7 +149,6 @@ public class ToolBarChart extends ScatterPlot {
      * @return - The filename to write this type of Bar chart to.
      */
     public static String generateBarChartFileName(Tool tool, BarChartType type) {
-
         String filename =
                 BenchmarkScore.TESTSUITE
                         + " v"
@@ -166,7 +171,7 @@ public class ToolBarChart extends ScatterPlot {
      * @param type - The Type of Bar Chart to create.
      * @return The created DataSet.
      */
-    public static DefaultCategoryDataset createToolDataSet(
+    private static DefaultCategoryDataset createToolDataSet(
             Tool targetTool, Map<String, CategoryResults> aveToolResults, BarChartType type) {
         final DefaultCategoryDataset dataset = new DefaultCategoryDataset();
 
@@ -215,14 +220,9 @@ public class ToolBarChart extends ScatterPlot {
      * the other tools and write those charts to tool/metric specific names.
      *
      * @param tool - The Tool to create the charts for.
-     * @param overallAveToolResults - A Map of each vuln category to the average CategoryResults for
-     *     that category.
      */
-    public static void generateComparisonCharts(
-            Tool tool, Map<String, CategoryResults> overallAveToolResults, File scoreCardDir) {
-
+    public void generateComparisonCharts(Tool tool) {
         if (BenchmarkScore.config.includePrecision) {
-
             // Generate Precision Chart
             // First create the Dataset required for the chart
             DefaultCategoryDataset toolPrecisionData =

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/ToolReport.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/ToolReport.java
@@ -20,7 +20,6 @@ package org.owasp.benchmarkutils.score.report;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.Map;
@@ -33,8 +32,15 @@ import org.owasp.benchmarkutils.score.TP_FN_TN_FP_Counts;
 import org.owasp.benchmarkutils.score.Tool;
 import org.owasp.benchmarkutils.score.ToolResults;
 import org.owasp.benchmarkutils.score.report.ToolBarChart.BarChartType;
+import org.owasp.benchmarkutils.score.report.html.ToolReportProvider;
 
-public class ToolReport {
+public class ToolReport implements ToolReportProvider {
+
+    private final Map<String, CategoryResults> overallAveToolResults;
+
+    public ToolReport(Map<String, CategoryResults> overallAveToolResults) {
+        this.overallAveToolResults = overallAveToolResults;
+    }
 
     /**
      * Generate an HTML report for whatever tool's results are passed in.
@@ -43,18 +49,11 @@ public class ToolReport {
      * @param title - The title of the HTML report to generate.
      * @param scorecardImageFile - The File that contains the scorecard image for this tool's
      *     results.
-     * @param actualCSVResultsFileName - The name of the actual results .csv file for this tool.
      * @return The generated HTML report for the supplied tool.
      * @throws IOException
-     * @throws URISyntaxException
      */
-    public static String generateHtml(
-            Tool currentTool,
-            String title,
-            File scorecardImageFile,
-            String actualCSVResultsFileName,
-            Map<String, CategoryResults> overallAveToolResults)
-            throws IOException, URISyntaxException {
+    public String generateHtml(Tool currentTool, String title, File scorecardImageFile)
+            throws IOException {
 
         ToolResults overallToolResults = currentTool.getOverallResults();
 
@@ -81,7 +80,7 @@ public class ToolReport {
         html = html.replace("${version}", currentTool.getTestSuiteVersion());
         html = html.replace("${projectlink}", BenchmarkScore.PROJECTLINKENTRY);
         html = html.replace("${cwecategoryname}", BenchmarkScore.config.cweCategoryName);
-        html = html.replace("${actualResultsFile}", actualCSVResultsFileName);
+        html = html.replace("${actualResultsFile}", currentTool.getActualResultsFileName());
 
         html = html.replace("${image}", scorecardImageFile.getName());
 

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/ToolBarChartProvider.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/ToolBarChartProvider.java
@@ -1,0 +1,25 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
+package org.owasp.benchmarkutils.score.report.html;
+
+import org.owasp.benchmarkutils.score.Tool;
+
+public interface ToolBarChartProvider {
+
+    void generateComparisonCharts(Tool tool);
+}

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/ToolReportProvider.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/ToolReportProvider.java
@@ -1,0 +1,27 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
+package org.owasp.benchmarkutils.score.report.html;
+
+import java.io.File;
+import java.io.IOException;
+import org.owasp.benchmarkutils.score.Tool;
+
+public interface ToolReportProvider {
+
+    String generateHtml(Tool currentTool, String title, File scorecardImageFile) throws IOException;
+}

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/ToolScorecard.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/html/ToolScorecard.java
@@ -1,0 +1,132 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
+package org.owasp.benchmarkutils.score.report.html;
+
+import static java.text.MessageFormat.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import org.owasp.benchmarkutils.score.CategoryResults;
+import org.owasp.benchmarkutils.score.Configuration;
+import org.owasp.benchmarkutils.score.Tool;
+import org.owasp.benchmarkutils.score.report.ScatterTools;
+import org.owasp.benchmarkutils.score.report.ToolBarChart;
+import org.owasp.benchmarkutils.score.report.ToolReport;
+
+public class ToolScorecard {
+
+    private final File scoreCardDir;
+    private final Configuration config;
+    private final String testSuite;
+    private final String fullTestSuiteName;
+
+    private ToolBarChartProvider toolBarChart;
+    private ToolReportProvider toolReport;
+
+    public ToolScorecard(
+            Map<String, CategoryResults> overallAveToolResults,
+            File scoreCardDir,
+            Configuration config,
+            String testSuite,
+            String fullTestSuiteName) {
+        this.scoreCardDir = scoreCardDir;
+        this.config = config;
+        this.testSuite = testSuite;
+        this.fullTestSuiteName = fullTestSuiteName;
+
+        this.toolBarChart = new ToolBarChart(overallAveToolResults, scoreCardDir);
+        this.toolReport = new ToolReport(overallAveToolResults);
+    }
+
+    public void setToolBarChart(ToolBarChartProvider toolBarChart) {
+        this.toolBarChart = toolBarChart;
+    }
+
+    public void setToolReport(ToolReportProvider toolReport) {
+        this.toolReport = toolReport;
+    }
+
+    public void generate(Tool tool) {
+        if (config.showAveOnlyMode && tool.isCommercial()) {
+            return;
+        }
+
+        toolBarChart.generateComparisonCharts(tool);
+
+        try {
+            Files.write(new File(reportPathFor(tool)).toPath(), reportHtml(tool).getBytes());
+            System.out.println("Scorecard written to: " + reportPathFor(tool));
+        } catch (Exception e) {
+            System.out.println("Error creating and/or saving tool HTML scorecard!");
+            e.printStackTrace();
+        }
+    }
+
+    private String reportHtml(Tool tool) throws IOException {
+        return toolReport.generateHtml(tool, titleFor(tool), storedGraphFor(tool));
+    }
+
+    private String reportPathFor(Tool tool) {
+        return scoreCardDir.getAbsolutePath() + File.separator + filenameFor(tool) + ".html";
+    }
+
+    private String titleFor(Tool tool) {
+        String fullTitle = fullTestSuiteName + " Scorecard for " + tool.getToolNameAndVersion();
+        // If not in anonymous mode OR the tool is not commercial, add the type at the end of
+        // the name. It's not added to anonymous commercial tools, because it would be
+        // redundant.
+        if (!config.anonymousMode || !tool.isCommercial()) {
+            fullTitle += " (" + tool.getToolType() + ")";
+        }
+        return fullTitle;
+    }
+
+    private File storedGraphFor(Tool tool) {
+        String shortTitle =
+                format(
+                        "{0} v{1} Scorecard for {2}",
+                        testSuite, tool.getTestSuiteVersion(), tool.getToolName());
+
+        File img = new File(scoreCardDir, filenameFor(tool) + ".png");
+
+        try {
+            graph(tool, shortTitle).writeChartToFile(img, 800);
+        } catch (IOException e) {
+            System.out.println("Error saving tool Scatter chart to disk!");
+            e.printStackTrace();
+        }
+
+        return img;
+    }
+
+    private ScatterTools graph(Tool tool, String shortTitle) {
+        return new ScatterTools(shortTitle, 800, tool.getOverallResults());
+    }
+
+    /**
+     * Returns the name of the file that contains this tool's scorecard, without the file extension.
+     */
+    public String filenameFor(Tool tool) {
+        return (format(
+                        "{0} v{1} Scorecard for {2}",
+                        testSuite, tool.getTestSuiteVersion(), tool.getToolNameAndVersion()))
+                .replace(' ', '_');
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/ToolScorecardTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/ToolScorecardTest.java
@@ -1,0 +1,185 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Sascha Knoop
+ * @created 2024
+ */
+package org.owasp.benchmarkutils.score.report.html;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.owasp.benchmarkutils.score.BenchmarkScore;
+import org.owasp.benchmarkutils.score.Configuration;
+import org.owasp.benchmarkutils.score.TestSuiteResults.ToolType;
+import org.owasp.benchmarkutils.score.Tool;
+import org.owasp.benchmarkutils.score.builder.ConfigurationBuilder;
+import org.owasp.benchmarkutils.score.builder.TestSuiteResultsBuilder;
+import org.owasp.benchmarkutils.score.builder.ToolBuilder;
+
+class ToolScorecardTest {
+
+    private File tmpDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tmpDir = Files.createTempDirectory("Benchmark.ToolScorecardTest").toFile();
+    }
+
+    @Test
+    void createsScorecard() throws IOException {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(false)
+                        .setAnonymousMode(false)
+                        .build();
+
+        BenchmarkScore.config = config;
+
+        ToolScorecard toolScorecard =
+                new ToolScorecard(emptyMap(), tmpDir, config, "TestSuite", "FullName");
+
+        AtomicBoolean toolBarChartCalled = new AtomicBoolean(false);
+
+        Tool someTool =
+                ToolBuilder.builder()
+                        .setIsCommercial(false)
+                        .setTestSuiteResults(
+                                TestSuiteResultsBuilder.builder()
+                                        .setToolname("Some Tool")
+                                        .setToolVersion("1.0")
+                                        .setToolType(ToolType.SAST)
+                                        .build())
+                        .build();
+
+        toolScorecard.setToolBarChart(
+                tool -> {
+                    assertEquals(someTool.getToolNameAndVersion(), tool.getToolNameAndVersion());
+
+                    toolBarChartCalled.set(true);
+                });
+
+        toolScorecard.setToolReport(
+                (currentTool, title, scorecardImageFile) ->
+                        currentTool.getToolNameAndVersion()
+                                + "\n"
+                                + title
+                                + "\n"
+                                + scorecardImageFile.getAbsolutePath());
+
+        toolScorecard.generate(someTool);
+
+        File[] files = requireNonNull(tmpDir.listFiles());
+        assertEquals(2, files.length);
+
+        assertTrue(fileWithEnding(files, "png").isPresent());
+
+        Optional<File> htmlFile = fileWithEnding(files, "html");
+
+        assertTrue(htmlFile.isPresent());
+        List<String> htmlLines = Files.readAllLines(htmlFile.get().toPath());
+
+        assertEquals(3, htmlLines.size());
+        assertEquals("Some Tool v1.0", htmlLines.get(0));
+        assertEquals("FullName Scorecard for Some Tool v1.0 (SAST)", htmlLines.get(1));
+        assertEquals(
+                tmpDir.getAbsolutePath()
+                        + File.separator
+                        + "TestSuite_v1.2_Scorecard_for_Some_Tool_v1.0.png",
+                htmlLines.get(2));
+
+        assertTrue(toolBarChartCalled.get());
+    }
+
+    private static Optional<File> fileWithEnding(File[] files, String ending) {
+        return Arrays.stream(files).filter(f -> f.getName().endsWith(ending)).findAny();
+    }
+
+    @Test
+    void doesNotCreateScorecardForCommercialToolsInAveOnlyMode() {
+        Configuration config = ConfigurationBuilder.builder().setShowAveOnlyMode(true).build();
+
+        BenchmarkScore.config = config;
+
+        ToolScorecard toolScorecard =
+                new ToolScorecard(emptyMap(), tmpDir, config, "TestSuite", "FullName");
+
+        AtomicBoolean toolBarChartCalled = new AtomicBoolean(false);
+
+        Tool someTool = ToolBuilder.builder().setIsCommercial(true).build();
+
+        toolScorecard.setToolBarChart(tool -> fail("generateComparisonCharts has been called"));
+        toolScorecard.setToolReport(
+                (currentTool, title, scorecardImageFile) -> fail("generateHtml has been called"));
+
+        toolScorecard.generate(someTool);
+
+        File[] files = requireNonNull(tmpDir.listFiles());
+        assertEquals(0, files.length);
+        assertFalse(toolBarChartCalled.get());
+    }
+
+    @Test
+    void omitsToolTypeForCommercialToolsInAnonymousMode() throws IOException {
+        Configuration config =
+                ConfigurationBuilder.builder()
+                        .setShowAveOnlyMode(false)
+                        .setAnonymousMode(true)
+                        .build();
+
+        BenchmarkScore.config = config;
+
+        ToolScorecard toolScorecard =
+                new ToolScorecard(emptyMap(), tmpDir, config, "TestSuite", "FullName");
+
+        Tool someTool =
+                ToolBuilder.builder()
+                        .setIsCommercial(true)
+                        .setTestSuiteResults(
+                                TestSuiteResultsBuilder.builder()
+                                        .setToolname("Some Tool")
+                                        .setToolVersion("1.0")
+                                        .setToolType(ToolType.SAST)
+                                        .build())
+                        .build();
+
+        toolScorecard.setToolBarChart(tool -> {});
+
+        toolScorecard.setToolReport((currentTool, title, scorecardImageFile) -> title);
+
+        toolScorecard.generate(someTool);
+
+        File[] files = requireNonNull(tmpDir.listFiles());
+
+        Optional<File> htmlFile = fileWithEnding(files, "html");
+
+        assertTrue(htmlFile.isPresent());
+        String content = Files.readString(htmlFile.get().toPath());
+
+        assertEquals("FullName Scorecard for Some Tool v1.0", content);
+    }
+}


### PR DESCRIPTION
The (domain) tool class also contains report generation code. It should not be there, so I extracted it to separate class. I created two interfaces so I can create tests without doing black magic with mocks.