### PR TITLE
Snyk reports on child CWEs for PathTraversal and password hashing

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
@@ -828,6 +828,20 @@ public class BenchmarkScore extends AbstractMojo {
                 }
             }
 
+            if (tool.startsWith("Snyk")) {
+                // Special case: Snyk reports CWE-916 (for insecure password hashing) while the
+                // Benchmark expects the parent CWE-328 (for weak hash in general)
+                if (!match && (expectedCWE == 328)) {
+                    match = (actualCWE == 916);
+                }
+
+                // Special case: Snyk reports CWE-23 (for relative path traversal) while the
+                // Benchmark expects the parent CWE-22 (for path traveral in general)
+                if (!match && (expectedCWE == 22)) {
+                    match = (actualCWE == 23);
+                }
+            }
+
             // return true if we find an exact match for a True Positive test
             if (match) {
                 return exp.isTruePositive();

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
@@ -828,20 +828,6 @@ public class BenchmarkScore extends AbstractMojo {
                 }
             }
 
-            if (tool.startsWith("Snyk")) {
-                // Special case: Snyk reports CWE-916 (for insecure password hashing) while the
-                // Benchmark expects the parent CWE-328 (for weak hash in general)
-                if (!match && (expectedCWE == 328)) {
-                    match = (actualCWE == 916);
-                }
-
-                // Special case: Snyk reports CWE-23 (for relative path traversal) while the
-                // Benchmark expects the parent CWE-22 (for path traveral in general)
-                if (!match && (expectedCWE == 22)) {
-                    match = (actualCWE == 23);
-                }
-            }
-
             // return true if we find an exact match for a True Positive test
             if (match) {
                 return exp.isTruePositive();

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/CweNumber.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/CweNumber.java
@@ -25,6 +25,9 @@ public class CweNumber {
     /** CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal') */
     public static int PATH_TRAVERSAL = 22;
 
+    /** CWE-23: Relative Path Traversal */
+    public static int RELATIVE_PATH_TRAVERSAL = 23;
+
     /**
      * CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command
      * Injection')
@@ -165,6 +168,9 @@ public class CweNumber {
 
     /** CWE-835: Loop with Unreachable Exit Condition ('Infinite Loop') */
     public static int LOOP_WITH_UNREACHABLE_EXIT = 835;
+
+    /** CWE-916: Use of Password Hash With Insufficient Computational Effort */
+    public static int PASSWORD_HASH_WITH_INSUFFICIENT_COMPUTATIONAL_EFFORT = 916;
 
     /** CWE-918: Server-Side Request Forgery (SSRF) */
     public static int SSRF = 918;

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SnykReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SnykReader.java
@@ -17,9 +17,24 @@
  */
 package org.owasp.benchmarkutils.score.parsers.sarif;
 
+import org.owasp.benchmarkutils.score.CweNumber;
+
 public class SnykReader extends SarifReader {
 
     public SnykReader() {
         super("SnykCode", true, CweSourceType.FIELD);
+    }
+
+    @Override
+    public int mapCwe(int cwe) {
+        if (cwe == CweNumber.PASSWORD_HASH_WITH_INSUFFICIENT_COMPUTATIONAL_EFFORT) {
+            return CweNumber.WEAK_HASH_ALGO;
+        }
+
+        if (cwe == CweNumber.RELATIVE_PATH_TRAVERSAL) {
+            return CweNumber.PATH_TRAVERSAL;
+        }
+
+        return super.mapCwe(cwe);
     }
 }

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/sarif/SnykReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/sarif/SnykReaderTest.java
@@ -59,4 +59,13 @@ class SnykReaderTest extends ReaderTestBase {
         assertEquals(CweNumber.INSECURE_COOKIE, result.get(1).get(0).getCWE());
         assertEquals(CweNumber.XPATH_INJECTION, result.get(2).get(0).getCWE());
     }
+
+    @Test
+    void readerMapsCwes() {
+        SnykReader reader = new SnykReader();
+        assertEquals(
+                CweNumber.WEAK_HASH_ALGO,
+                reader.mapCwe(CweNumber.PASSWORD_HASH_WITH_INSUFFICIENT_COMPUTATIONAL_EFFORT));
+        assertEquals(CweNumber.PATH_TRAVERSAL, reader.mapCwe(CweNumber.RELATIVE_PATH_TRAVERSAL));
+    }
 }


### PR DESCRIPTION
This updates `BenchmarkScore` to reflect Snyks behavior of reporting the specific child CWE instead of the expected parent CWE for both path traversal and weak hash CWEs.