### PR TITLE
refactor AppScanReader to use provided CWE

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReader.java
@@ -17,25 +17,47 @@
  */
 package org.owasp.benchmarkutils.score.parsers;
 
-import java.io.StringReader;
+import static java.lang.Integer.parseInt;
+
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.owasp.benchmarkutils.score.BenchmarkScore;
 import org.owasp.benchmarkutils.score.CweNumber;
 import org.owasp.benchmarkutils.score.ResultFile;
 import org.owasp.benchmarkutils.score.TestCaseResult;
 import org.owasp.benchmarkutils.score.TestSuiteResults;
-import org.w3c.dom.Document;
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
-import org.xml.sax.InputSource;
 
-// This is the new HCL AppScan DAST reader, where they generate ".xml" files. HCL calls this AppScan
-// Standard.
-// The 'old' reader is AppScanDynamicReader, which supports the previous .xml format from IBM.
+/**
+ * This is the new HCL AppScan DAST reader, where they generate ".xml" files. HCL calls this AppScan
+ * Standard. The 'old' reader is AppScanDynamicReader, which supports the previous .xml format from
+ * IBM.
+ */
 public class HCLAppScanStandardReader extends Reader {
+
+    private final List<String> ignoreList = new ArrayList<>();
+
+    public HCLAppScanStandardReader() {
+        ignoreList.add("attContentSecurityPolicyObjectSrc");
+        ignoreList.add("attContentSecurityPolicyScriptSrc");
+        ignoreList.add("attCachedSSL");
+        ignoreList.add("attJSCookie");
+        ignoreList.add("attLinkInjection");
+        ignoreList.add("attUndefinedState");
+        ignoreList.add("bodyParamsInQuery");
+        ignoreList.add("ContentSecurityPolicy");
+        ignoreList.add("ContentTypeOptions");
+        ignoreList.add("GD_EmailAddress");
+        ignoreList.add("GETParamOverSSL");
+        ignoreList.add("GV_SQLErr");
+        ignoreList.add("HSTS");
+        ignoreList.add("MHTMLXSS");
+        ignoreList.add("OpenSource");
+        ignoreList.add("phishingInFrames");
+        ignoreList.add("OldTLS");
+        ignoreList.add("ShellShockCheck");
+        ignoreList.add("SriSupport");
+    }
 
     @Override
     public boolean canRead(ResultFile resultFile) {
@@ -47,245 +69,75 @@ public class HCLAppScanStandardReader extends Reader {
 
     @Override
     public TestSuiteResults parse(ResultFile resultFile) throws Exception {
-        DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
-        // Prevent XXE
-        docBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
-        InputSource is = new InputSource(new StringReader(resultFile.content()));
-        Document doc = docBuilder.parse(is);
-
-        Node root = doc.getDocumentElement();
-        Node scanInfo = getNamedChild("scan-information", root);
-
-        Node scanConfiguration = getNamedChild("scan-configuration", root);
-        String startingUrl = getNamedChild("starting-url", scanConfiguration).getTextContent();
+        Node root = resultFile.xml().getDocumentElement();
 
         TestSuiteResults tr =
                 new TestSuiteResults("HCL AppScan Standard", true, TestSuiteResults.ToolType.DAST);
 
-        // version is usually like 9.3.0 but sometimes like 9.3.0 iFix005. We trim off the part
-        // after the space char.
-        Node version = getNamedChild("product-version", scanInfo);
-        //    System.out.println("Product version is: " + version.getTextContent());
-        if (version != null) {
-            tr.setToolVersion(version.getTextContent().split(" ")[0]);
-        }
-        
-        Node allIssueVariants = getNamedChild("issue-group", root);
-        List<Node> variants = getNamedChildren("item", allIssueVariants);
-        
-        List<String> testCaseElementsFromVariants = new ArrayList<>();
-        
-        
-        if (variants.isEmpty()) {
-            // Handle non-variant issue types , Older xml format as in 9.x release versions and
-            // before
-            // First get the type of vuln, and if we don't care about that type, move on
-        	 Node allIssues = getNamedChild("url-group", root);
-        	 List<Node> vulnerabilities = getNamedChildren("item", allIssues);
-        	 for (Node vulnerability : vulnerabilities) {
-                 String issueType = getNamedChild("issue-type", vulnerability).getTextContent();
+        setTime(root, tr);
+        setVersion(root, tr);
 
-                 String url = getNamedChild("name", vulnerability).getTextContent();
-                 
-            TestCaseResult tcr = TestCaseLookup(issueType, url);
-            if (tcr != null) tr.put(tcr);
-        	 }
+        List<Node> variants = getNamedChildren("item", getNamedChild("issue-group", root));
+
+        for (Node variant : variants) {
+            int xmlCwe = parseInt(getNamedChild("cwe", variant).getTextContent());
+            String variantIssueType = getNamedChild("issue-type", variant).getTextContent().trim();
+
+            getNamedChildren("item", getNamedChild("variant-group", variant)).stream()
+                    .map(node -> extractFilenameWithoutEnding(extractUrlFrom(node)))
+                    .filter(filename -> filename.startsWith(BenchmarkScore.TESTCASENAME))
+                    .forEach(
+                            filename -> {
+                                TestCaseResult tcr = new TestCaseResult();
+
+                                tcr.setNumber(testNumber(filename));
+                                tcr.setCategory(variantIssueType); // TODO: Is this right?
+                                tcr.setCWE(cweLookup(variantIssueType, xmlCwe));
+                                tcr.setEvidence(variantIssueType);
+
+                                tr.put(tcr);
+                            });
         }
-        
-        else {
-            // Handle issues which are Variants, new xml format after 10.x release
-        	for (Node variant : variants) {
-	            String variantIssueType = getNamedChild("issue-type", variant).getTextContent().trim();
-	            // System.out.println("Variant Url Ref ID: " + variantUrlRefId);
-	
-	            // Add the record only if the issue type matches for the relevant variants
-	                Node variantNodes = getNamedChild("variant-group", variant);
-	                List<Node> variantNodeChildren = getNamedChildren("item", variantNodes);
-	                for (Node variantNodeChild : variantNodeChildren) {
-	                    String httpTraffic =
-	                            getNamedChild("test-http-traffic", variantNodeChild).getTextContent();
-	                    String[] variantUrl = httpTraffic.split(" ");
-	
-	                    String benchMarkTestCase = variantUrl[1].trim();
-	
-	                    if (benchMarkTestCase.contains("BenchmarkTest")) {
-	                        String[] urlElements = benchMarkTestCase.split("/");
-	
-	                        String testAreaUrl =
-	                                startingUrl
-	                                        + urlElements[urlElements.length - 2]
-	                                        + "/"
-	                                        + urlElements[urlElements.length - 1];
-	                        String testArea = testAreaUrl.split("\\?")[0]; // .split strips off the -##
-	
-	                        if (testArea.contains("BenchmarkTest"))
-	                            testCaseElementsFromVariants.add(testArea);
-			                    TestCaseResult tcr = TestCaseLookup(variantIssueType, testArea);
-			                    if (tcr != null) 
-			                    	tr.put(tcr);
-	                    }
-	                }
-            }
-        }
+
         return tr;
     }
 
-    /// Issues which are not variants
-    private TestCaseResult TestCaseLookup(String issueType, String url) {
-        String[] urlElements = url.split("/");
-        String testArea =
-                urlElements[urlElements.length - 2].split("-")[0]; // .split strips off the -##
+    private void setTime(Node root, TestSuiteResults tr) {
+        tr.setTime(
+                getNamedChild("scan-Duration", getNamedChild("scan-summary", root))
+                        .getTextContent());
+    }
 
-        int vtype = cweLookup(issueType, testArea);
+    private static String extractUrlFrom(Node variantNodeChild) {
+        String[] variantUrl =
+                getNamedChild("test-http-traffic", variantNodeChild).getTextContent().split(" ");
 
-        // Then get the filename containing the vuln. And if not in a test case, skip it.
-        // Parse out test number from:
-        // https://localhost:port/benchmark/testarea-##/BenchmarkTest02603
-        int startOfTestCase = url.lastIndexOf("/") + 1;
-        String testcase = url.substring(startOfTestCase, url.length());
-        // if test case has extension (e.g., BenchmarkTestCase#####.html), strip it off.
-        testcase = testcase.split("\\.")[0];
-        // System.out.println("Candidate test case is: " + testcase);
-        if (testcase.startsWith(BenchmarkScore.TESTCASENAME)) {
-            // if (tn == -1) System.out.println("Found vuln outside of test case of type: " +
-            // issueType);
+        return variantUrl[1].trim();
+    }
 
-            // Add the vuln found in a test case to the results for this tool
-            TestCaseResult tcr = new TestCaseResult();
-            tcr.setNumber(testNumber(testcase));
-            tcr.setCategory(issueType); // TODO: Is this right?
-            tcr.setCWE(vtype);
-            tcr.setEvidence(issueType);
-            return tcr;
+    /*
+     * Version is usually like 9.3.0 but sometimes like 9.3.0 iFix005. We trim off the part after the space char.
+     */
+    private static void setVersion(Node root, TestSuiteResults tr) {
+        Node version = getNamedChild("product-version", getNamedChild("scan-information", root));
+
+        if (version != null) {
+            tr.setToolVersion(version.getTextContent().split(" ")[0]);
         }
-        return null;
     }
 
-    // Fetch Issues listed as variants, to cater to post 10.x release xml format
-    private List<String> variantLookup(
-            String issueType, String itemID, String startingUrl, List<Node> variants) {
-        List<String> testCaseElementsFromVariants = new ArrayList<>();
-
-        // System.out.println("Variant Lookup Item ID: " + itemID);
-
-        for (Node variant : variants) {
-            String variantUrlRefId = getNamedChild("url", variant).getTextContent().trim();
-            String variantIssueType = getNamedChild("issue-type", variant).getTextContent().trim();
-            // System.out.println("Variant Url Ref ID: " + variantUrlRefId);
-
-            // Add the record only if the issue type matches for the relevant variants
-            if (issueType.equals(variantIssueType) && itemID.equals(variantUrlRefId)) {
-                Node variantNodes = getNamedChild("variant-group", variant);
-                List<Node> variantNodeChildren = getNamedChildren("item", variantNodes);
-                for (Node variantNodeChild : variantNodeChildren) {
-                    String httpTraffic =
-                            getNamedChild("test-http-traffic", variantNodeChild).getTextContent();
-                    String[] variantUrl = httpTraffic.split(" ");
-
-                    String benchMarkTestCase = variantUrl[1].trim();
-
-                    if (benchMarkTestCase.contains("BenchmarkTest")) {
-                        String[] urlElements = benchMarkTestCase.split("/");
-
-                        String testAreaUrl =
-                                startingUrl
-                                        + urlElements[urlElements.length - 2]
-                                        + "/"
-                                        + urlElements[urlElements.length - 1];
-                        String testArea = testAreaUrl.split("\\?")[0]; // .split strips off the -##
-
-                        if (testArea.contains("BenchmarkTest"))
-                            testCaseElementsFromVariants.add(testArea);
-                    }
-                }
-            }
-        }
-
-        return testCaseElementsFromVariants;
-    }
-
-    private int cweLookup(String vtype, String testArea) {
-        int cwe = cweLookup(vtype); // Do the standard CWE lookup
-
-        // Then map some to other CWEs based on the test area being processed.
-        if ("xpathi".equals(testArea) && cwe == 89) cwe = 643; // CWE for XPath injection
-        if ("ldapi".equals(testArea) && cwe == 89) cwe = 90; // CWE for LDAP injection
-
-        return cwe;
-    }
-
-    private int cweLookup(String vtype) {
+    private int cweLookup(String vtype, int xmlCwe) {
         switch (vtype) {
-            case "attDirectoryFound":
-            case "attDirOptions":
-            case "attFileUnix":
-                return CweNumber.PATH_TRAVERSAL;
-
-            case "attApplicationRemoteCodeExecutionAdns":
-            case "attCodeInjectionInSystemCall":
-            case "attCommandInjectionAdns":
-            case "attCommandInjectionUnixTws":
-            case "attFileParamPipe":
-                return CweNumber.COMMAND_INJECTION;
-
-            case "attCrossSiteScripting":
-                return CweNumber.XSS;
-
-            case "attBlindSqlInjectionStrings":
-            case "attSqlInjectionChecks":
-                return CweNumber.SQL_INJECTION;
-
-            case "attLDAPInjection":
-            case "attLDAPInjection2":
-            case "attBlindLDAPInjection":
-                return CweNumber.LDAP_INJECTION;
-
-            case "SHA1CipherSuites":
-                return CweNumber.WEAK_HASH_ALGO; // Better if set to 327?
-
-            case "passParamGET":
-                return CweNumber.UNPROTECTED_CREDENTIALS_TRANSPORT;
-
-            case "attRespCookieNotSecureSSL":
-                return CweNumber.INSECURE_COOKIE;
-
             case "attXPathInjection":
             case "attBlindXpathInjectionSingleQuote":
             case "attBlindXPathInjection":
                 return CweNumber.XPATH_INJECTION;
-
-                // These don't map to anything we care about
-            case "attContentSecurityPolicyObjectSrc":
-            case "attContentSecurityPolicyScriptSrc":
-            case "attCachedSSL":
-            case "attJSCookie":
-                // case "attLinkInjection" : return 00;
-            case "attUndefinedState":
-            case "bodyParamsInQuery":
-            case "ContentSecurityPolicy":
-            case "ContentTypeOptions":
-            case "GD_EmailAddress":
-            case "GETParamOverSSL":
-            case "GV_SQLErr":
-                // case "HSTS" : return 00;
-
-                // Microsoft MHTML XSS - Giving AppScan XSS 'credit' for this introduces ~2.4% False
-                // Positives and no real ones so I (shivababuh) disabled it instead
-            case "MHTMLXSS":
-                // case "OpenSource" : return 00;  // Known vuln in open source lib.
-                // case "phishingInFrames" : return 00;
-            case "OldTLS":
-            case "ShellShockCheck":
-            case "SriSupport":
-                // case "SSL_CertWithBadCN" : return 00;
-                // case "XSSProtectionHeader" : return 00;
-                return CweNumber.DONTCARE;
-
-            default:
-                System.out.println(
-                        "WARNING: HCL AppScan Standard-Unrecognized finding type: " + vtype);
         }
-        return 0;
+
+        if (ignoreList.contains(vtype)) {
+            return CweNumber.DONTCARE;
+        }
+
+        return xmlCwe;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/MendReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/MendReader.java
@@ -47,7 +47,7 @@ public class MendReader extends Reader {
                 for (Report.EngineResults.Result.Vulnerability vulnerability :
                         result.vulnerabilities) {
                     try {
-                        String testfile = extractFilename(vulnerability.filename);
+                        String testfile = extractFilenameWithoutEnding(vulnerability.filename);
 
                         if (testfile.startsWith(BenchmarkScore.TESTCASENAME)) {
                             TestCaseResult tcr = new TestCaseResult();

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Rapid7Reader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Rapid7Reader.java
@@ -47,7 +47,7 @@ public class Rapid7Reader extends Reader {
 
         for (Report.Vulnerability vulnerability : report.vulnerabilities) {
             try {
-                String testfile = extractFilename(vulnerability.url);
+                String testfile = extractFilenameWithoutEnding(vulnerability.url);
 
                 if (testfile.startsWith(BenchmarkScore.TESTCASENAME)) {
                     TestCaseResult tcr = new TestCaseResult();

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
@@ -274,11 +274,15 @@ public abstract class Reader {
         }
     }
 
-    public static String extractFilename(String path) {
+    public static String extractFilenameWithoutEnding(String path) {
         try {
-            path = removeUrlPart(path);
+            String name = new File(fixWindowsPath(removeUrlPart(path))).getName();
 
-            return new File(fixWindowsPath(path)).getName();
+            if (name.contains(".")) {
+                return name.substring(0, name.lastIndexOf("."));
+            } else {
+                return name;
+            }
         } catch (Throwable t) {
             return "";
         }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SarifReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SarifReader.java
@@ -236,7 +236,7 @@ public abstract class SarifReader extends Reader {
     private TestCaseResult testCaseResultFor(JSONObject result, Map<String, Integer> mappings) {
         TestCaseResult tcr = new TestCaseResult();
 
-        String className = extractFilename(resultUri(result));
+        String className = extractFilenameWithoutEnding(resultUri(result));
 
         if (!className.startsWith(BenchmarkScore.TESTCASENAME)) {
             return null;

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/ReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/ReaderTest.java
@@ -69,14 +69,14 @@ public class ReaderTest {
                 "c:\\somepath\\BenchmarkTest00042|BenchmarkTest00042",
                 "c:/somepath/BenchmarkTest00042|BenchmarkTest00042",
                 "/somepath/BenchmarkTest00042|BenchmarkTest00042",
-                "http://somewhere/BenchmarkTest00042.html|BenchmarkTest00042.html",
-                "http://somewhere/BenchmarkTest00042.html?foo=bar|BenchmarkTest00042.html",
-                "https://somewhere:8443/BenchmarkTest00042.html|BenchmarkTest00042.html",
+                "http://somewhere/BenchmarkTest00042.html|BenchmarkTest00042",
+                "http://somewhere/BenchmarkTest00042.html?foo=bar|BenchmarkTest00042",
+                "https://somewhere:8443/BenchmarkTest00042.html|BenchmarkTest00042",
                 "/something/else|else",
-                "/something/else.html|else.html"
+                "/something/else.html|else"
             },
             delimiter = '|')
-    public void extractsFilenameFromPath(String input, String expected) {
-        assertEquals(expected, Reader.extractFilename(input));
+    public void extractsFilenameWithoutEndingFromPath(String input, String expected) {
+        assertEquals(expected, Reader.extractFilenameWithoutEnding(input));
     }
 }

--- a/plugin/src/test/resources/testfiles/Benchmark_HCLAppScanStandardReader-v10.0.6.xml
+++ b/plugin/src/test/resources/testfiles/Benchmark_HCLAppScanStandardReader-v10.0.6.xml
@@ -4,26 +4,9 @@
         <product-name>HCL AppScan Standard</product-name>
         <product-version>10.0.6</product-version>
     </scan-information>
-    <scan-configuration>
-        <starting-url>https://localhost:8443/benchmark</starting-url>
-    </scan-configuration>
     <scan-summary>
         <scan-Duration>01:23:45.6789012</scan-Duration>
     </scan-summary>
-    <url-group>
-        <item id="1111111111">
-            <name>https://localhost:8443/benchmark/sqli-00/BenchmarkTest00001</name>
-            <issue-type>attSqlInjectionChecks</issue-type>
-        </item>
-        <item id="2222222222">
-            <name>https://localhost:8443/benchmark/sqli-00/BenchmarkTest00002</name>
-            <issue-type>attSqlInjectionChecks</issue-type>
-        </item>
-        <item id="3333333333">
-            <name>https://localhost:8443/</name>
-            <issue-type>attSameSiteCookie</issue-type>
-        </item>
-    </url-group>
     <issue-group total="4">
         <item id="1234567890" id-v2="-1234567890">
             <cwe>89</cwe>


### PR DESCRIPTION
This PR refactors the AppScanReader to simply use CWE number from result file instead of hardcoded matching. I also removed all Code for old version because at least v9 (which, according to comment, counts as "old version") already has all the required fields. In other words, the refactored class reads both v9 and v10 without problems.

After talking to @davewichers, I removed a small "hack" in the old reader which changed the CWE based on the path. This does not affect overall score since it only changes a few (2?) results.