### PR TITLE
Make tags field optional (for V25 results)

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SonarQubeJsonReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SonarQubeJsonReader.java
@@ -131,13 +131,18 @@ public class SonarQubeJsonReader extends Reader {
                 tcr.setNumber(testNumber(filename));
                 String rule = finding.getString("rule");
                 String squid = rule.substring(rule.indexOf(":") + 1);
-                if (squid == null || squid.equals("none")) {
+
+                if (squid.equals("none")) {
                     return null;
                 }
-                int cwe = SonarQubeReader.cweLookup(squid);
-                tcr.setCWE(cwe);
-                tcr.setCategory(finding.getJSONArray("tags").toString());
+
+                tcr.setCWE(SonarQubeReader.cweLookup(squid));
                 tcr.setEvidence(finding.getString("message"));
+
+                if (finding.has("tags")) {
+                    tcr.setCategory(finding.getJSONArray("tags").toString());
+                }
+
                 return tcr;
             }
 

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SonarQubeReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SonarQubeReader.java
@@ -515,9 +515,16 @@ public class SonarQubeReader extends Reader {
                         .WEAK_CRYPTO_ALGO; // Benchmark Vuln: Encryption algorithms should be used
                 // with secure mode and padding scheme
             case "S5547":
+            case "S4790":
                 return CweNumber
                         .WEAK_CRYPTO_ALGO; // Benchmark Vuln: Cipher algorithms should be robust
+            case "S3330":
+                return CweNumber.COOKIE_WITHOUT_HTTPONLY;
 
+            case "S1153":
+            case "S6851":
+            case "S6853":
+            case "S2119":
             case "CallToDeprecatedMethod":
             case "ClassVariableVisibilityCheck":
             case "DuplicatedBlocks":

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/SonarQubeJsonReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/SonarQubeJsonReaderTest.java
@@ -30,23 +30,31 @@ import org.owasp.benchmarkutils.score.TestSuiteResults;
 
 public class SonarQubeJsonReaderTest extends ReaderTestBase {
 
-    private ResultFile resultFile;
+    private ResultFile resultFileV9;
+    private ResultFile resultFileV25;
 
     @BeforeEach
     void setUp() {
-        resultFile = TestHelper.resultFileOf("testfiles/Benchmark_sonarqube-v9.1.0.47736.json");
+        resultFileV9 = TestHelper.resultFileOf("testfiles/Benchmark_sonarqube-v9.1.0.47736.json");
+        resultFileV25 =
+                TestHelper.resultFileOf("testfiles/Benchmark_sonarqube-v25.1.0.102122.json");
         BenchmarkScore.TESTCASENAME = "BenchmarkTest";
     }
 
     @Test
-    public void onlySonarQubeJsonReaderReportsCanReadAsTrue() {
-        assertOnlyMatcherClassIs(this.resultFile, SonarQubeJsonReader.class);
+    public void onlySonarQubeJsonReaderReportsCanReadAsTrueForV9() {
+        assertOnlyMatcherClassIs(this.resultFileV9, SonarQubeJsonReader.class);
     }
 
     @Test
-    void readerHandlesGivenResultFile() throws Exception {
+    public void onlySonarQubeJsonReaderReportsCanReadAsTrueForV25() {
+        assertOnlyMatcherClassIs(this.resultFileV25, SonarQubeJsonReader.class);
+    }
+
+    @Test
+    void readerHandlesGivenV9ResultFile() throws Exception {
         SonarQubeJsonReader reader = new SonarQubeJsonReader();
-        TestSuiteResults result = reader.parse(resultFile);
+        TestSuiteResults result = reader.parse(resultFileV9);
 
         assertEquals(TestSuiteResults.ToolType.SAST, result.getToolType());
         assertFalse(result.isCommercial());
@@ -56,5 +64,20 @@ public class SonarQubeJsonReaderTest extends ReaderTestBase {
 
         assertEquals(CweNumber.WEAK_CRYPTO_ALGO, result.get(1).get(0).getCWE());
         assertEquals(CweNumber.SQL_INJECTION, result.get(2).get(0).getCWE());
+    }
+
+    @Test
+    void readerHandlesGivenV25ResultFile() throws Exception {
+        SonarQubeJsonReader reader = new SonarQubeJsonReader();
+        TestSuiteResults result = reader.parse(resultFileV25);
+
+        assertEquals(TestSuiteResults.ToolType.SAST, result.getToolType());
+        assertFalse(result.isCommercial());
+        assertEquals("SonarQube", result.getToolName());
+
+        assertEquals(2, result.getTotalResults());
+
+        assertEquals(CweNumber.SQL_INJECTION, result.get(1).get(0).getCWE());
+        assertEquals(CweNumber.WEAK_CRYPTO_ALGO, result.get(2).get(0).getCWE());
     }
 }

--- a/plugin/src/test/resources/testfiles/Benchmark_sonarqube-v25.1.0.102122.json
+++ b/plugin/src/test/resources/testfiles/Benchmark_sonarqube-v25.1.0.102122.json
@@ -1,0 +1,48 @@
+{
+  "date": "Tuesday, Jan 01, 1970",
+  "inNewCodePeriod": false,
+  "allBugs": true,
+  "fixMissingRule": false,
+  "noSecurityHotspot": false,
+  "noRulesInReport": true,
+  "vulnerabilityPhrase": "Vulnerability",
+  "noCoverage": true,
+  "vulnerabilityPluralPhrase": "Vulnerabilities",
+  "sonarBaseURL": "http://localhost:9876",
+  "sonarComponent": "benchmark",
+  "rules": {},
+  "issues": [
+    {
+      "rule": "java:S2077",
+      "severity": "CRITICAL",
+      "status": "TO_REVIEW",
+      "component": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00001.java",
+      "line": 57,
+      "description": "Formatting SQL queries is security-sensitive",
+      "message": "Make sure using a dynamically formatted SQL query is safe here.",
+      "key": "e1518810-c118-4cad-ae23-f337cf913d65"
+    },
+    {
+      "rule": "java:S5547",
+      "severity": "CRITICAL",
+      "status": "OPEN",
+      "component": "src/main/java/org/owasp/benchmark/testcode/BenchmarkTest00002.java",
+      "line": 72,
+      "description": "Cipher algorithms should be robust",
+      "message": "Use a strong cipher algorithm.",
+      "key": "ffecce86-2afe-4fe3-b5b2-f06e24d549db"
+    }
+  ],
+  "hotspotKeys": [
+    "9012d4af-be33-4e0d-8c68-705d8fef08c4",
+    "0c0fbd12-b778-44b8-a0f6-dbfa9afc0872"
+  ],
+  "deltaAnalysis": "No",
+  "qualityGateStatus": false,
+  "summary": {
+    "blocker": 0,
+    "critical": 1015,
+    "major": 3072,
+    "minor": 6613
+  }
+}


### PR DESCRIPTION
As described in title, the `tags` field does not exist in issues anymore. Not sure if got removed by SonarQube or gets omitted from [sonar-report](https://github.com/soprasteria/sonar-report). Be it as it may, now it's optional for `SonarQubeJsonReader` 🤷‍♂️.