### PR TITLE
Added LDAP Injection support in WapitiReader

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/WapitiReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/WapitiReader.java
@@ -123,6 +123,8 @@ public class WapitiReader extends Reader {
                 return CweNumber.XSS;
             case "89": // Normal and Blind SQL Injection
                 return CweNumber.SQL_INJECTION;
+            case "90":
+                return CweNumber.LDAP_INJECTION;
             case "352":
                 return CweNumber.CSRF;
             case "611":


### PR DESCRIPTION
LDAP Injection (CWE-90) was previously missing in the lookup function.
Before:
![image](https://github.com/user-attachments/assets/499a6ab8-0174-4376-9c02-e6224e2e1ed2)
After:
![image](https://github.com/user-attachments/assets/39a1c75f-281a-43fc-96b4-cfd29ac3347f)
