### PR TITLE
Disable snakeyml warning for duplicate keys

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/Configuration.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/Configuration.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.util.Map;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -76,7 +77,20 @@ public class Configuration {
 
     public final Report report;
 
-    private static final Yaml yaml = new Yaml();
+    private static final Yaml yaml = new Yaml(loaderOptions());
+
+    /**
+     * Custom loader options to disable warning for duplicate key (which is not helpful, because
+     * it's intended behaviour to merge keys from multiple files)
+     */
+    private static LoaderOptions loaderOptions() {
+        LoaderOptions loaderOptions = new LoaderOptions();
+
+        loaderOptions.setAllowDuplicateKeys(true);
+        loaderOptions.setWarnOnDuplicateKeys(false);
+
+        return loaderOptions;
+    }
 
     public static Configuration fromDefaultConfig() {
         return fromInputStream(resourceAsStream(DEFAULT_CONFIG), DEFAULT_SUCCESS_MESSAGE);


### PR DESCRIPTION
As requested via mail, this PR disables the warning snakeyml introduced in one of the latest updates.