### PR TITLE
Added support for Black Duck Coverity (formerly Synopsys) for newer versions

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CoverityReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CoverityReader.java
@@ -67,7 +67,7 @@ public class CoverityReader extends Reader {
             TestCaseResult tcr = new TestCaseResult();
             String filename = null;
 
-            if (version == 3) {
+            if (version >= 3) {
                 filename = finding.getString("mainEventFilePathname");
                 filename = filename.replaceAll("\\\\", "/");
                 filename = filename.substring(filename.lastIndexOf('/') + 1);

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/CoverityReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/CoverityReaderTest.java
@@ -40,14 +40,16 @@ public class CoverityReaderTest extends ReaderTestBase {
     }
 
     @Test
-    public void onlyCoverityReaderReportsCanReadAsTrue() {
+    public void onlyCoverityReaderReportsCanReadAsTrueForV3() {
         assertOnlyMatcherClassIs(this.resultFile_v3, CoverityReader.class);
+    }
+
+    public void onlyCoverityReaderReportsCanReadAsTrueForV10() {
         assertOnlyMatcherClassIs(this.resultFile_v10, CoverityReader.class);
     }
 
     @Test
-    void readerHandlesGivenResultFile() throws Exception {
-        // For Coverity v3.0
+    void readerHandlesGivenResultFileInV3() throws Exception {
         CoverityReader reader = new CoverityReader();
         TestSuiteResults result = reader.parse(resultFile_v3);
 
@@ -59,10 +61,12 @@ public class CoverityReaderTest extends ReaderTestBase {
 
         assertEquals(CweNumber.PATH_TRAVERSAL, result.get(1).get(0).getCWE());
         assertEquals(CweNumber.SQL_INJECTION, result.get(2).get(0).getCWE());
+    }
 
-        // For Coverity v10.0
-        reader = new CoverityReader();
-        result = reader.parse(resultFile_v10);
+    @Test
+    void readerHandlesGivenResultFileInV10() throws Exception {
+        CoverityReader reader = new CoverityReader();
+        TestSuiteResults result = reader.parse(resultFile_v10);
 
         assertEquals(TestSuiteResults.ToolType.SAST, result.getToolType());
         assertTrue(result.isCommercial());

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/CoverityReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/CoverityReaderTest.java
@@ -30,23 +30,39 @@ import org.owasp.benchmarkutils.score.TestSuiteResults;
 
 public class CoverityReaderTest extends ReaderTestBase {
 
-    private ResultFile resultFile;
+    private ResultFile resultFile_v3, resultFile_v10;
 
     @BeforeEach
     void setUp() {
-        resultFile = TestHelper.resultFileOf("testfiles/Benchmark_Coverity-v3.0.json");
+        resultFile_v3 = TestHelper.resultFileOf("testfiles/Benchmark_Coverity-v3.0.json");
+        resultFile_v10 = TestHelper.resultFileOf("testfiles/Benchmark_Coverity-v10.0.json");
         BenchmarkScore.TESTCASENAME = "BenchmarkTest";
     }
 
     @Test
     public void onlyCoverityReaderReportsCanReadAsTrue() {
-        assertOnlyMatcherClassIs(this.resultFile, CoverityReader.class);
+        assertOnlyMatcherClassIs(this.resultFile_v3, CoverityReader.class);
+        assertOnlyMatcherClassIs(this.resultFile_v10, CoverityReader.class);
     }
 
     @Test
     void readerHandlesGivenResultFile() throws Exception {
+        // For Coverity v3.0
         CoverityReader reader = new CoverityReader();
-        TestSuiteResults result = reader.parse(resultFile);
+        TestSuiteResults result = reader.parse(resultFile_v3);
+
+        assertEquals(TestSuiteResults.ToolType.SAST, result.getToolType());
+        assertTrue(result.isCommercial());
+        assertEquals("Coverity Code Advisor", result.getToolName());
+
+        assertEquals(2, result.getTotalResults());
+
+        assertEquals(CweNumber.PATH_TRAVERSAL, result.get(1).get(0).getCWE());
+        assertEquals(CweNumber.SQL_INJECTION, result.get(2).get(0).getCWE());
+
+        // For Coverity v10.0
+        reader = new CoverityReader();
+        result = reader.parse(resultFile_v10);
 
         assertEquals(TestSuiteResults.ToolType.SAST, result.getToolType());
         assertTrue(result.isCommercial());

--- a/plugin/src/test/resources/testfiles/Benchmark_Coverity-v10.0.json
+++ b/plugin/src/test/resources/testfiles/Benchmark_Coverity-v10.0.json
@@ -1,0 +1,107 @@
+{
+  "type" : "Coverity issues",
+  "formatVersion" : 10,
+  "suppressedIssueCount" : 0,
+  "issues" : [
+    {
+      "mergeKey" : "00000000000000000000000000000000",
+      "occurrenceCountForMK" : 1,
+      "occurrenceNumberInMK" : 1,
+      "checkerName" : "PATH_MANIPULATION",
+      "subcategory" : "none",
+      "extra" : "fileName",
+      "domain" : "STATIC_JAVA",
+      "mainEventFilePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00001.java",
+      "strippedMainEventFilePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00001.java",
+      "mainEventLineNumber" : 0,
+      "properties" : {},
+      "functionDisplayName" : "org.owasp.benchmark.testcode.BenchmarkTest00001.doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)",
+      "functionMangledName" : "org.owasp.benchmark.testcode.BenchmarkTest00001.doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)",
+      "ordered" : true,
+      "events" : [
+        {
+          "covLStrEventDescription" : "Lorem Ipsum",
+          "eventDescription" : "Lorem Ipsum",
+          "eventNumber" : 0,
+          "eventTreePosition" : "0",
+          "eventSet" : 0,
+          "eventTag" : "tainted_source",
+          "filePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00001.java",
+          "strippedFilePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00001.java",
+          "lineNumber" : 0,
+          "main" : false,
+          "moreInformationId" : null,
+          "remediation" : false,
+          "events" : null
+        }
+      ],
+      "stateOnServer" : null,
+      "checkerProperties" : {
+        "category" : "High impact security",
+        "categoryDescription" : "High impact security",
+        "cweCategory" : "22",
+        "issueKinds" : [
+          "SECURITY"
+        ],
+        "eventSetCaptions" : [],
+        "impact" : "High",
+        "impactDescription" : "High",
+        "subcategoryLocalEffect" : "Lorem Ipsum",
+        "subcategoryShortDescription" : "Lorem Ipsum",
+        "subcategoryLongDescription" : "Lorem Ipsum"
+      }
+    },
+    {
+      "mergeKey" : "00000000000000000000000000000000",
+      "occurrenceCountForMK" : 1,
+      "occurrenceNumberInMK" : 1,
+      "checkerName" : "SQLI",
+      "subcategory" : "sink",
+      "extra" : "sql",
+      "domain" : "STATIC_JAVA",
+      "mainEventFilePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00002.java",
+      "strippedMainEventFilePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00002.java",
+      "mainEventLineNumber" : 0,
+      "properties" : {},
+      "functionDisplayName" : "org.owasp.benchmark.testcode.BenchmarkTest00002.doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)",
+      "functionMangledName" : "org.owasp.benchmark.testcode.BenchmarkTest00002.doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)",
+      "ordered" : true,
+      "events" : [
+        {
+          "covLStrEventDescription" : "Lorem Ipsum",
+          "eventDescription" : "Lorem Ipsum",
+          "eventNumber" : 1,
+          "eventTreePosition" : "0",
+          "eventSet" : 0,
+          "eventTag" : "tainted_source",
+          "filePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00002.java",
+          "strippedFilePathname" : "somepath\\src\\main\\java\\org\\owasp\\benchmark\\testcode\\BenchmarkTest00002.java",
+          "lineNumber" : 0,
+          "main" : false,
+          "moreInformationId" : null,
+          "remediation" : false,
+          "events" : null
+        }
+      ],
+      "stateOnServer" : null,
+      "checkerProperties" : {
+        "category" : "High impact security",
+        "categoryDescription" : "High impact security",
+        "cweCategory" : "89",
+        "issueKinds" : [
+          "SECURITY"
+        ],
+        "eventSetCaptions" : [
+          "Lorem Ipsum"
+        ],
+        "impact" : "High",
+        "impactDescription" : "High",
+        "subcategoryLocalEffect" : "Lorem Ipsum",
+        "subcategoryShortDescription" : "Lorem Ipsum",
+        "subcategoryLongDescription" : "Lorem Ipsum"
+      }
+    }
+  ],
+  "desktopAnalysisSettings" : null,
+  "error" : null
+}


### PR DESCRIPTION
Added support for Black Duck Coverity (formerly Synopsys) for newer versions (version 10 as of the date of this PR).

Newer versions greater than 3 were handled in the "else" block even though they can be safely parsed by the same configuration for version 3.