### PR TITLE
Add SiteShadow SARIF reader

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
@@ -38,6 +38,7 @@ import org.owasp.benchmarkutils.score.parsers.sarif.FortifySarifReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.PTAIReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.PrecautionReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.SemgrepSarifReader;
+import org.owasp.benchmarkutils.score.parsers.sarif.SiteShadowReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.SnykReader;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -106,6 +107,7 @@ public abstract class Reader {
                 new ShiftLeftReader(),
                 new ShiftLeftScanReader(),
                 new SnappyTickReader(),
+                new SiteShadowReader(),
                 new SnykReader(),
                 new SonarQubeJsonReader(),
                 new SonarQubeReader(),

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SiteShadowReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SiteShadowReader.java
@@ -1,0 +1,25 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Michael (SiteShadow)
+ * @created 2026
+ */
+package org.owasp.benchmarkutils.score.parsers.sarif;
+
+public class SiteShadowReader extends SarifReader {
+
+    public SiteShadowReader() {
+        super("SiteShadow", false, CweSourceType.TAG);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SiteShadowReader` extending `SarifReader` for parsing SiteShadow SAST results
- SiteShadow is an open-source taint analysis tool using tree-sitter WASM parsing
- Uses `CweSourceType.TAG` — CWEs are encoded in SARIF rule property tags (e.g., `["CWE-89", "security"]`)
- Registered in `Reader.allReaders()`

## Context
SiteShadow performs graph-based intraprocedural and interprocedural taint analysis for Java (and other languages). On OWASP Benchmark v1.2, it achieves:
- **100% TPR, 0% FPR** on all 7 taint-relevant CWEs (CWE-22, 78, 79, 89, 90, 501, 643)
- 902/902 true positives detected, 0/796 false positives

A companion PR to BenchmarkJava will add the SARIF results file and generated scorecard.

## Test plan
- [x] BenchmarkUtils builds successfully with the new reader
- [x] Scorecard generated correctly from SiteShadow SARIF results file
- [ ] Verify reader is picked up by `canRead()` for SiteShadow SARIF files

🤖 Generated with [Claude Code](https://claude.com/claude-code)