### PR TITLE
Add SiteShadow SARIF reader

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/Reader.java
@@ -38,6 +38,7 @@ import org.owasp.benchmarkutils.score.parsers.sarif.FortifySarifReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.PTAIReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.PrecautionReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.SemgrepSarifReader;
+import org.owasp.benchmarkutils.score.parsers.sarif.SiteShadowReader;
 import org.owasp.benchmarkutils.score.parsers.sarif.SnykReader;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -106,6 +107,7 @@ public abstract class Reader {
                 new ShiftLeftReader(),
                 new ShiftLeftScanReader(),
                 new SnappyTickReader(),
+                new SiteShadowReader(),
                 new SnykReader(),
                 new SonarQubeJsonReader(),
                 new SonarQubeReader(),

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SiteShadowReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/sarif/SiteShadowReader.java
@@ -1,0 +1,25 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Michael (SiteShadow)
+ * @created 2026
+ */
+package org.owasp.benchmarkutils.score.parsers.sarif;
+
+public class SiteShadowReader extends SarifReader {
+
+    public SiteShadowReader() {
+        super("SiteShadow", false, CweSourceType.TAG);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SiteShadowReader.java` — a minimal SARIF reader for SiteShadow SAST results
- Extends `SarifReader` base class, uses `CweSourceType.TAG` for CWE extraction from rule tags
- Registered in `Reader.allReaders()`

SiteShadow is a SAST tool that outputs SARIF 2.1.0 with CWE tags on each rule. This reader enables the Benchmark scorecard to parse those results.

## Results
SiteShadow v1.0.0 achieves **100% score across all 11 CWE categories** (100% TPR, 0% FPR) on Benchmark v1.2. Results PR to follow in BenchmarkJava.

🤖 Generated with [Claude Code](https://claude.com/claude-code)