### PR TITLE
Fix: NullPointerException on Commercial Average Scorecard (#268)

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java
@@ -962,7 +962,7 @@ public class BenchmarkScore extends AbstractMojo {
                                         + commercialAveragesTable.filename());
                 // Resources in a jar file have to be loaded as streams. Not directly as Files.
                 InputStream vulnTemplateStream =
-                        CL.getResourceAsStream(scoreCardDir + "/commercialAveTemplate.html");
+                        CL.getResourceAsStream(SCORECARDDIRNAME + "/commercialAveTemplate.html");
                 String html = IOUtils.toString(vulnTemplateStream, StandardCharsets.UTF_8);
                 html = html.replace("${testsuite}", BenchmarkScore.TESTSUITENAME.fullName());
                 html = html.replace("${version}", TESTSUITEVERSION);

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/BenchmarkScoreTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/BenchmarkScoreTest.java
@@ -18,9 +18,11 @@
 package org.owasp.benchmarkutils.score;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.PrintStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,5 +110,17 @@ public class BenchmarkScoreTest {
                 () -> BenchmarkScore.loadConfigFromCommandLineArguments(new String[] {null, "b"}));
 
         expectUsageMessage();
+    }
+
+    @Test
+    void commercialAveTemplateResolvesViaClasspathConstant() {
+        String resourcePath =
+                BenchmarkScore.SCORECARDDIRNAME + "/commercialAveTemplate.html";
+        InputStream stream =
+                BenchmarkScore.class.getClassLoader().getResourceAsStream(resourcePath);
+
+        assertNotNull(
+                stream,
+                "commercialAveTemplate.html must be loadable via SCORECARDDIRNAME classpath lookup");
     }
 }


### PR DESCRIPTION
# Fix: NullPointerException on Commercial Average Scorecard (#268)

**Closes #268**

---

## What Changed

One line in `plugin/src/main/java/org/owasp/benchmarkutils/score/BenchmarkScore.java` (line 965):

```diff
-  CL.getResourceAsStream(scoreCardDir + "/commercialAveTemplate.html");
+  CL.getResourceAsStream(SCORECARDDIRNAME + "/commercialAveTemplate.html");
```

## Why It Was Broken

`scoreCardDir` is a `java.io.File` object representing the filesystem output directory. `getResourceAsStream()` expects a classpath resource path. These are two completely different things.

When Java evaluates `scoreCardDir + "/commercialAveTemplate.html"`, it calls `File.toString()`, which returns a filesystem path. That filesystem path gets passed to `getResourceAsStream()`, which looks for it on the classpath, doesn't find it, and returns `null`. Then `IOUtils.toString(null)` throws the NullPointerException.

## Why It Worked Before (By Accident)

With the default config (`resultsfileordir: "results"`):

1. `new File("results").getParent()` returns `null` because `"results"` is a single path component with no parent directory
2. `new File(null, "scorecard")` collapses to just `File("scorecard")`
3. `File("scorecard").toString()` produces `"scorecard"`
4. `getResourceAsStream("scorecard/commercialAveTemplate.html")` finds the resource because it happens to live at that classpath

The filesystem directory name and the classpath resource path matched by pure coincidence.

## Why It Breaks With Nested Paths

When a user provides a nested `resultsfileordir` in their YAML config (e.g. `"some/dir/results"`):

1. `new File("some/dir/results").getParent()` returns `"some/dir"`
2. `scoreCardDir` becomes `File("some/dir/scorecard")`
3. `scoreCardDir.toString()` produces `"some/dir/scorecard"`
4. `getResourceAsStream("some/dir/scorecard/commercialAveTemplate.html")` finds nothing, returns `null`, and the NPE follows

This is why Dave and darkspirit510 could not reproduce it. They tested with the default config, which has no nested path.

## Why The Reporter's Original Patch Was Symptom-Only

The reporter proposed hardcoding `"scorecard/commercialAveTemplate.html"`. That would fix the NPE, but as darkspirit510 correctly noted, the deeper issue is that nested `resultsfileordir` paths are not fully supported in BenchmarkUtils. This fix addresses the NPE only. Broader nested-path support is a separate effort.

## How The Fix Works

The codebase already has a constant `SCORECARDDIRNAME = "scorecard"` (line 88) used for exactly this purpose elsewhere:

| Location | Pattern | Status |
|---|---|---|
| ToolReport.java:64 | `SCORECARDDIRNAME + "/template.html"` | Correct |
| BenchmarkScore.java:910 | `"scorecard/vulntemplate.html"` | Correct |
| BenchmarkScore.java:965 | `scoreCardDir + "/commercialAveTemplate.html"` | Was the bug |

The fix replaces `scoreCardDir` with `SCORECARDDIRNAME`, making line 965 consistent with the two working patterns. The classpath lookup now always produces `"scorecard/commercialAveTemplate.html"` regardless of what filesystem path the user configures.
