### PR TITLE
Implement Code Block Failure Detection (Issue #5) and Extra CWE Detector (Issue #6)

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/tools/CalculateToolCodeBlocksSupport.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/tools/CalculateToolCodeBlocksSupport.java
@@ -131,8 +131,8 @@ public class CalculateToolCodeBlocksSupport extends BenchmarkCrawler {
                         .build());
         options.addOption(
                 Option.builder("r")
-                        .longOpt("file")
-                        .desc("a scorecard generated toolResults.csv file")
+                        .longOpt("results")
+                        .desc("a scorecard generated toolResults.csv file, or a directory of them")
                         .hasArg()
                         .required()
                         .build());
@@ -178,32 +178,52 @@ public class CalculateToolCodeBlocksSupport extends BenchmarkCrawler {
         }
     }
 
-    /** Calculate the code block support for the specified tool for the specified test suite. */
+    /** Calculate the code block support for the specified tool(s) for the specified test suite. */
     @Override
     protected void run() {
+        // If the results parameter is a directory, iterate all scorecard CSVs in it
+        if (csvResultsFile.isDirectory()) {
+            File[] scorecardFiles = csvResultsFile.listFiles(
+                    f -> f.isFile() && f.getName().contains("Scorecard_for_")
+                            && f.getName().endsWith(".csv"));
+            if (scorecardFiles == null || scorecardFiles.length == 0) {
+                System.out.println(
+                        "ERROR: No scorecard CSV files found in directory: "
+                                + csvResultsFile.getAbsolutePath());
+                return;
+            }
+            System.out.println(
+                    "Processing " + scorecardFiles.length + " scorecard files from: "
+                            + csvResultsFile.getAbsolutePath() + "\n");
+            for (File scorecardFile : scorecardFiles) {
+                // Extract tool name from filename
+                String fileName = scorecardFile.getName();
+                int forIdx = fileName.indexOf("Scorecard_for_");
+                String toolName = fileName.substring(forIdx + "Scorecard_for_".length())
+                        .replace(".csv", "");
+                System.out.println(
+                        "\n========================================================");
+                System.out.println("=== Tool: " + toolName + " ===");
+                System.out.println(
+                        "========================================================");
+                runForOneTool(scorecardFile);
+            }
+            return;
+        }
 
-        // Initialize the expected and actual results data structure from the
-        //   TESTSUITE-attack-http.xml and results.csv already loaded.
-        // Merge the .csv results with the codeblock details so you know which test cases
-        //   pass/fail.
-        //  - Probably can use the same structures used in ScoreCard generation, which is: TBD
-        //  - Should use an array of: TestCaseResult - This class represents a single test case
-        // result. It documents the expected result (real),
-        //    and the actual result (result). Such an array is already contained in:
-        // TestSuiteResults, but its contents have to be created using
-        //    put(TestCaseResult) one test case at a time.
-        // List<AbstractTestCaseRequest> testcases = this.testSuite.getTestCases() is already loaded
+        // Single file mode
+        runForOneTool(csvResultsFile);
+    }
 
-        // NOTE: The last 2 params are dummy values as I don't think we care about their type (yet)
+    private void runForOneTool(File toolCsvFile) {
         TestSuiteResults theToolResults =
                 new TestSuiteResults(this.testSuite.getName(), false, ToolType.SAST);
 
-        // Get all the TestCase info loaded from TESTSUITE-attack-http.xml file
         List<AbstractTestCaseRequest> theTestcases = this.testSuite.getTestCases();
         int testSuiteSize = theTestcases.size();
 
         try {
-            java.io.Reader inReader = new java.io.FileReader(csvResultsFile);
+            java.io.Reader inReader = new java.io.FileReader(toolCsvFile);
             CSVParser recordParser = CSVFormat.Builder.create().setHeader().build().parse(inReader);
 
             List<CSVRecord> records = recordParser.getRecords();
@@ -457,6 +477,72 @@ public class CalculateToolCodeBlocksSupport extends BenchmarkCrawler {
                 }
             }
 
+            // 3b2. Issue #5 Pass 2: Single-unknown isolation.
+            // For each FN, count how many of its snippets are NOT supported.
+            // If exactly 1 is unsupported, that snippet is the isolated root cause.
+            List<TestCaseResult> combinationFailures = new ArrayList<>();
+            for (int tc : theToolResults.keySet()) {
+                TestCaseResult theResult = theToolResults.get(tc).get(0);
+                if (!theResult.isTruePositive() || theResult.isPassed()) continue;
+
+                CodeBlockSupportResults source =
+                        sourceCodeBlocksResults.get(theResult.getSource());
+                CodeBlockSupportResults dataflow =
+                        dataflowCodeBlocksResults.get(theResult.getDataFlow());
+                CodeBlockSupportResults sink = sinkCodeBlocksResults.get(theResult.getSink());
+
+                source.fnTestCases.add(theResult.getName());
+                if (dataflow != null && !dataflow.name.isEmpty())
+                    dataflow.fnTestCases.add(theResult.getName());
+                sink.fnTestCases.add(theResult.getName());
+
+                List<CodeBlockSupportResults> unknowns = new ArrayList<>();
+                if (!source.supported) unknowns.add(source);
+                if (dataflow != null && !dataflow.name.isEmpty() && !dataflow.supported)
+                    unknowns.add(dataflow);
+                if (!sink.supported) unknowns.add(sink);
+
+                if (unknowns.size() == 1) {
+                    unknowns.get(0).isolatedFnCause.add(theResult.getName());
+                } else if (unknowns.isEmpty()) {
+                    combinationFailures.add(theResult);
+                }
+            }
+
+            // 3b3. Issue #5 Stage 2: FP isolation.
+            // For each FP, identify which snippet(s) make it safe.
+            // If exactly 1 safe snippet, the tool fails to recognize it as safe.
+            List<TestCaseResult> sanityCheckFailures = new ArrayList<>();
+            for (int tc : theToolResults.keySet()) {
+                TestCaseResult theResult = theToolResults.get(tc).get(0);
+                if (theResult.isTruePositive() || theResult.isPassed()) continue;
+
+                CodeBlockSupportResults source =
+                        sourceCodeBlocksResults.get(theResult.getSource());
+                CodeBlockSupportResults dataflow =
+                        dataflowCodeBlocksResults.get(theResult.getDataFlow());
+                CodeBlockSupportResults sink = sinkCodeBlocksResults.get(theResult.getSink());
+
+                // Sanity check: all snippets are supported but tool still FPs
+                boolean allSupported = source.supported
+                        && (dataflow.name.isEmpty() || dataflow.supported)
+                        && sink.supported;
+                if (allSupported) {
+                    sanityCheckFailures.add(theResult);
+                }
+
+                // Which snippet makes this test case safe (not a real vuln)?
+                List<CodeBlockSupportResults> safeSnippets = new ArrayList<>();
+                if (!source.truePositive) safeSnippets.add(source);
+                if (!dataflow.name.isEmpty() && !dataflow.truePositive)
+                    safeSnippets.add(dataflow);
+                if (!sink.truePositive) safeSnippets.add(sink);
+
+                if (safeSnippets.size() == 1) {
+                    safeSnippets.get(0).isolatedFpCause.add(theResult.getName());
+                }
+            }
+
             // 3c. Calculate which sinks appear to be unsupported or always cause false positives
             String Always_FP_Output = "\n"; // Used to print all the FPs AFTER the Always FN values
             for (CodeBlockSupportResults sinkResult : sinkCodeBlocksResults.values()) {
@@ -568,28 +654,87 @@ public class CalculateToolCodeBlocksSupport extends BenchmarkCrawler {
                     System.out.println("Always FP: " + dataflowResult);
             }
 
-            /*
-                        // Print out codeblock coordinates of suspect False Positives
-                        for (int tc : theToolResults.keySet()) {
-                            TestCaseResult theResult = theToolResults.get(tc).get(0); // Always only one.
-                            boolean passed = theResult.isPassed();
-                            CodeBlockSupportResults source = sourceCodeBlocksResults.get(theResult.getSource());
-                            CodeBlockSupportResults dataflow =
-                                    dataflowCodeBlocksResults.get(theResult.getDataFlow());
-                            CodeBlockSupportResults sink = sinkCodeBlocksResults.get(theResult.getSink());
+            // --- Issue #5 Pass 2 Report: Isolated FN Root Causes ---
+            System.out.println("\n--- Pass 2: Isolated FN Root Causes ---");
+            boolean foundIsolated = false;
+            for (CodeBlockSupportResults sinkResult : sinkCodeBlocksResults.values()) {
+                if (!sinkResult.isolatedFnCause.isEmpty()) {
+                    System.out.println("  " + sinkResult.toIsolationString());
+                    foundIsolated = true;
+                }
+            }
+            for (CodeBlockSupportResults sourceResult : sourceCodeBlocksResults.values()) {
+                if (!sourceResult.isolatedFnCause.isEmpty()) {
+                    System.out.println("  " + sourceResult.toIsolationString());
+                    foundIsolated = true;
+                }
+            }
+            for (CodeBlockSupportResults dataflowResult : dataflowCodeBlocksResults.values()) {
+                if (!dataflowResult.isolatedFnCause.isEmpty()) {
+                    System.out.println("  " + dataflowResult.toIsolationString());
+                    foundIsolated = true;
+                }
+            }
+            if (!foundIsolated) {
+                System.out.println("  (none found)");
+            }
+            if (!combinationFailures.isEmpty()) {
+                System.out.println(
+                        "  Combination failures (all snippets supported, tool still misses): "
+                                + combinationFailures.size());
+                for (TestCaseResult cf : combinationFailures) {
+                    System.out.println("    " + cf.toString());
+                }
+            }
 
-                            if (!theResult.isTruePositive() && !passed && !sink.reported && !source.reported) {
-                                if (source.supported && dataflow.supported) {
-                                    System.out.println(
-                                            "False Positive possibly caused by SINK, since both source and dataflow supported. For: "
-                                                    + theResult.toString());
-                                    System.out.println("  " + source.toString());
-                                    System.out.println("  " + dataflow.toString());
-                                    System.out.println("  " + sink.toString());
-                                }
-                            }
-                        }
-            */
+            // --- Issue #5 Sanity Check ---
+            if (!sanityCheckFailures.isEmpty()) {
+                System.out.println(
+                        "\n--- Sanity Check: FPs where all snippets are supported ("
+                                + sanityCheckFailures.size() + ") ---");
+                for (TestCaseResult sf : sanityCheckFailures) {
+                    System.out.println("  " + sf.toString());
+                }
+            }
+
+            // --- Issue #5 Stage 2 Report: Isolated FP Root Causes ---
+            System.out.println("\n--- Stage 2: FP Root Causes (safe snippets tool doesn't recognize) ---");
+            boolean foundFPIsolated = false;
+            for (CodeBlockSupportResults sinkResult : sinkCodeBlocksResults.values()) {
+                if (!sinkResult.isolatedFpCause.isEmpty()) {
+                    System.out.println(
+                            "  [SINK] " + sinkResult.name
+                                    + " (" + sinkResult.vulnCat + ", safe) -- "
+                                    + sinkResult.isolatedFpCause.size()
+                                    + " FPs isolated to this snippet");
+                    foundFPIsolated = true;
+                }
+            }
+            for (CodeBlockSupportResults sourceResult : sourceCodeBlocksResults.values()) {
+                if (!sourceResult.isolatedFpCause.isEmpty()) {
+                    System.out.println(
+                            "  [SOURCE] " + sourceResult.name
+                                    + " (safe) -- "
+                                    + sourceResult.isolatedFpCause.size()
+                                    + " FPs isolated to this snippet");
+                    foundFPIsolated = true;
+                }
+            }
+            for (CodeBlockSupportResults dataflowResult : dataflowCodeBlocksResults.values()) {
+                if (!dataflowResult.isolatedFpCause.isEmpty()) {
+                    String displayName =
+                            dataflowResult.name.isEmpty() ? "NoDataFlow" : dataflowResult.name;
+                    System.out.println(
+                            "  [DATAFLOW] " + displayName
+                                    + " (safe) -- "
+                                    + dataflowResult.isolatedFpCause.size()
+                                    + " FPs isolated to this snippet");
+                    foundFPIsolated = true;
+                }
+            }
+            if (!foundFPIsolated) {
+                System.out.println("  (none found)");
+            }
 
             // Print out codeblock coordinates of the rest of the False Positives, ignoring all with
             // sinks or sources already known to cause FPs

--- a/plugin/src/main/java/org/owasp/benchmarkutils/tools/CodeBlockSupportResults.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/tools/CodeBlockSupportResults.java
@@ -1,5 +1,8 @@
 package org.owasp.benchmarkutils.tools;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /*
  * This class is used to contain the results, per codeblock type, of how well a tool did with respect
  * to that codeblock.
@@ -38,6 +41,13 @@ class CodeBlockSupportResults {
     // the tool to always flag this test case as a TP
     int numFPSinksWhereSourceDataflowAreTruePositivesUsed = 0;
     int numFPSinksWhereSourceDataflowAreTruePositivesPassed = 0;
+
+    // Issue #5: Track actual test case names for bidirectional mapping and isolation analysis
+    Set<String> fnTestCases = new HashSet<>();
+    // FNs where THIS is the single unsupported snippet (isolated root cause)
+    Set<String> isolatedFnCause = new HashSet<>();
+    // FPs where THIS is the single safe snippet the tool fails to recognize
+    Set<String> isolatedFpCause = new HashSet<>();
 
     CodeBlockSupportResults(String name, String type, boolean truePositive) {
         this.name = name;
@@ -116,6 +126,15 @@ class CodeBlockSupportResults {
                 + numFPTestCasesPassed
                 + ", supported: "
                 + supported;
+    }
+
+    public String toIsolationString() {
+        String displayName = ("DATAFLOW".equals(type) && "".equals(name)) ? "NoDataFlow" : name;
+        return "[" + type + "] " + displayName
+                + ("SINK".equals(type) ? " (" + vulnCat + ")" : "")
+                + " -- " + isolatedFnCause.size() + " FNs isolated to this snippet"
+                + (isolatedFpCause.isEmpty() ? ""
+                        : ", " + isolatedFpCause.size() + " FPs isolated to this snippet");
     }
 
     public String toStringForFalsePositiveSinks() {

--- a/plugin/src/main/java/org/owasp/benchmarkutils/tools/DetectExtraCWEs.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/tools/DetectExtraCWEs.java
@@ -1,0 +1,340 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * <p>Implements Issue #6: Add extra CWEs found detector.
+ * Detects vulnerabilities found by tools outside of the intentional test cases.
+ *
+ * <p>Normal mode: For each tool, report CWEs from the expected set that are detected in test cases
+ * where that CWE is NOT expected (e.g., tool reports CWE-89 in a hash test case).
+ *
+ * <p>Hard mode: Report ANY CWE detected in a test case where that CWE is not expected, including
+ * CWEs not in the benchmark's expected set at all.
+ */
+package org.owasp.benchmarkutils.tools;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.owasp.benchmarkutils.score.BenchmarkScore;
+import org.owasp.benchmarkutils.score.ResultFile;
+import org.owasp.benchmarkutils.score.TestCaseResult;
+import org.owasp.benchmarkutils.score.TestSuiteResults;
+import org.owasp.benchmarkutils.score.parsers.Reader;
+import org.owasp.benchmarkutils.score.service.ExpectedResultsProvider;
+
+public class DetectExtraCWEs {
+
+    private File expectedResultsFile;
+    private File resultsDir;
+    private String mode = "both"; // "normal", "hard", or "both"
+
+    private static class ExpectedTestCase {
+        final String name;
+        final String category;
+        final int cwe;
+        final boolean vulnerable;
+
+        ExpectedTestCase(String name, String category, int cwe, boolean vulnerable) {
+            this.name = name;
+            this.category = category;
+            this.cwe = cwe;
+            this.vulnerable = vulnerable;
+        }
+    }
+
+    private static class ExtraFinding {
+        final String testName;
+        final int reportedCWE;
+        final int expectedCWE;
+        final String type; // "CWE_MISMATCH" or "UNKNOWN_CWE"
+
+        ExtraFinding(String testName, int reportedCWE, int expectedCWE, String type) {
+            this.testName = testName;
+            this.reportedCWE = reportedCWE;
+            this.expectedCWE = expectedCWE;
+            this.type = type;
+        }
+    }
+
+    public void processCommandLineArgs(String[] args) {
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+
+        Options options = new Options();
+        options.addOption(
+                Option.builder("e")
+                        .longOpt("expected")
+                        .desc("expectedresults CSV file")
+                        .hasArg()
+                        .required()
+                        .build());
+        options.addOption(
+                Option.builder("r")
+                        .longOpt("results")
+                        .desc("directory containing raw tool result files")
+                        .hasArg()
+                        .required()
+                        .build());
+        options.addOption(
+                Option.builder("m")
+                        .longOpt("mode")
+                        .desc("detection mode: normal, hard, or both (default: both)")
+                        .hasArg()
+                        .build());
+
+        try {
+            CommandLine line = parser.parse(options, args);
+
+            String expectedPath = line.getOptionValue("e");
+            expectedResultsFile = new File(expectedPath);
+            if (!expectedResultsFile.exists()) {
+                throw new RuntimeException(
+                        "Expected results file not found: " + expectedPath);
+            }
+
+            String resultsPath = line.getOptionValue("r");
+            resultsDir = new File(resultsPath);
+            if (!resultsDir.exists() || !resultsDir.isDirectory()) {
+                throw new RuntimeException(
+                        "Results directory not found: " + resultsPath);
+            }
+
+            if (line.hasOption("m")) {
+                mode = line.getOptionValue("m");
+            }
+        } catch (ParseException e) {
+            formatter.printHelp("DetectExtraCWEs", options);
+            throw new RuntimeException("Error parsing arguments: ", e);
+        }
+    }
+
+    public void run() {
+        try {
+            // 1. Load expected results
+            Map<Integer, ExpectedTestCase> expected = loadExpectedResults();
+            Set<Integer> expectedCWEs = new HashSet<>();
+            for (ExpectedTestCase tc : expected.values()) {
+                expectedCWEs.add(tc.cwe);
+            }
+            System.out.println(
+                    "Loaded " + expected.size() + " expected test cases with "
+                            + expectedCWEs.size() + " distinct CWEs: " + expectedCWEs);
+
+            // 2. Process each raw result file
+            File[] resultFiles = resultsDir.listFiles(f -> f.isFile());
+            if (resultFiles == null || resultFiles.length == 0) {
+                System.out.println("ERROR: No result files found in: " + resultsDir);
+                return;
+            }
+
+            for (File resultFile : resultFiles) {
+                // Skip expected results files
+                if (resultFile.getName().startsWith("expectedresults")) continue;
+
+                try {
+                    ResultFile rf = new ResultFile(resultFile);
+                    Reader reader = null;
+                    for (Reader r : Reader.allReaders()) {
+                        if (r.canRead(rf)) {
+                            reader = r;
+                            break;
+                        }
+                    }
+                    if (reader == null) continue;
+
+                    TestSuiteResults toolResults = reader.parse(rf);
+                    String toolName = toolResults.getToolName();
+                    if (toolResults.getToolVersion() != null) {
+                        toolName += " v" + toolResults.getToolVersion();
+                    }
+
+                    analyzeToolResults(toolName, toolResults, expected, expectedCWEs);
+                } catch (Exception e) {
+                    System.out.println(
+                            "WARNING: Could not parse " + resultFile.getName()
+                                    + ": " + e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            System.out.println("ERROR: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private void analyzeToolResults(
+            String toolName,
+            TestSuiteResults toolResults,
+            Map<Integer, ExpectedTestCase> expected,
+            Set<Integer> expectedCWEs) {
+
+        List<ExtraFinding> normalFindings = new ArrayList<>();
+        List<ExtraFinding> hardFindings = new ArrayList<>();
+
+        // For each finding the tool reported
+        for (int tc : toolResults.keySet()) {
+            List<TestCaseResult> results = toolResults.get(tc);
+            for (TestCaseResult tcr : results) {
+                int reportedCWE = tcr.getCWE();
+                if (reportedCWE <= 0) continue; // Skip unmapped findings
+
+                ExpectedTestCase expectedTC = expected.get(tc);
+                if (expectedTC == null) {
+                    // Finding for a test case number not in the expected results
+                    // (could be non-test file mapped to -1, or an invalid number)
+                    continue;
+                }
+
+                // Check if the reported CWE matches the expected CWE for this test case
+                if (reportedCWE != expectedTC.cwe) {
+                    if (expectedCWEs.contains(reportedCWE)) {
+                        // Normal: a known CWE detected in the wrong test case
+                        normalFindings.add(
+                                new ExtraFinding(
+                                        expectedTC.name,
+                                        reportedCWE,
+                                        expectedTC.cwe,
+                                        "CWE_MISMATCH"));
+                    } else {
+                        // Hard: a CWE not even in the benchmark's expected set
+                        hardFindings.add(
+                                new ExtraFinding(
+                                        expectedTC.name,
+                                        reportedCWE,
+                                        expectedTC.cwe,
+                                        "UNKNOWN_CWE"));
+                    }
+                }
+            }
+        }
+
+        // Report
+        boolean hasFindings =
+                (!normalFindings.isEmpty() && ("normal".equals(mode) || "both".equals(mode)))
+                        || (!hardFindings.isEmpty()
+                                && ("hard".equals(mode) || "both".equals(mode)));
+
+        if (!hasFindings) return;
+
+        System.out.println("\n=== " + toolName + " ===");
+
+        if ("normal".equals(mode) || "both".equals(mode)) {
+            if (normalFindings.isEmpty()) {
+                System.out.println("  NORMAL: No extra known-CWE findings.");
+            } else {
+                System.out.println(
+                        "  NORMAL: Known CWEs in wrong test cases ("
+                                + normalFindings.size() + " findings):");
+                // Group by reported CWE for readability
+                TreeMap<Integer, List<ExtraFinding>> byCWE = new TreeMap<>();
+                for (ExtraFinding ef : normalFindings) {
+                    byCWE.computeIfAbsent(ef.reportedCWE, k -> new ArrayList<>()).add(ef);
+                }
+                for (Map.Entry<Integer, List<ExtraFinding>> entry : byCWE.entrySet()) {
+                    System.out.println(
+                            "    CWE-" + entry.getKey() + " found in "
+                                    + entry.getValue().size() + " non-matching test cases:");
+                    for (ExtraFinding ef : entry.getValue()) {
+                        System.out.println(
+                                "      " + ef.testName + " (expected CWE-" + ef.expectedCWE + ")");
+                    }
+                }
+            }
+        }
+
+        if ("hard".equals(mode) || "both".equals(mode)) {
+            if (hardFindings.isEmpty()) {
+                System.out.println("  HARD: No extra non-benchmark CWE findings.");
+            } else {
+                System.out.println(
+                        "  HARD: Non-benchmark CWEs detected ("
+                                + hardFindings.size() + " findings):");
+                TreeMap<Integer, List<ExtraFinding>> byCWE = new TreeMap<>();
+                for (ExtraFinding ef : hardFindings) {
+                    byCWE.computeIfAbsent(ef.reportedCWE, k -> new ArrayList<>()).add(ef);
+                }
+                for (Map.Entry<Integer, List<ExtraFinding>> entry : byCWE.entrySet()) {
+                    System.out.println(
+                            "    CWE-" + entry.getKey() + " found in "
+                                    + entry.getValue().size() + " test cases:");
+                    for (ExtraFinding ef : entry.getValue()) {
+                        System.out.println(
+                                "      " + ef.testName + " (expected CWE-" + ef.expectedCWE + ")");
+                    }
+                }
+            }
+        }
+    }
+
+    private Map<Integer, ExpectedTestCase> loadExpectedResults() throws Exception {
+        Map<Integer, ExpectedTestCase> expected = new HashMap<>();
+        try (FileReader fileReader = new FileReader(expectedResultsFile);
+                CSVParser parser =
+                        CSVFormat.Builder.create().setHeader().build().parse(fileReader)) {
+
+            // Detect test suite name from header
+            String testCaseName = null;
+            for (String header : parser.getHeaderMap().keySet()) {
+                if (header.contains(ExpectedResultsProvider.PREFIX)) {
+                    int idx = header.indexOf(ExpectedResultsProvider.PREFIX);
+                    testCaseName = header.substring(0, idx).trim() + BenchmarkScore.TEST;
+                    BenchmarkScore.TESTCASENAME = testCaseName;
+                    break;
+                }
+            }
+            if (testCaseName == null) {
+                throw new RuntimeException(
+                        "Could not detect test suite name from expected results CSV header");
+            }
+
+            for (CSVRecord record : parser) {
+                String name = record.get(ExpectedResultsProvider.TEST_NAME);
+                if (!name.startsWith(testCaseName)) continue;
+
+                String category = record.get(ExpectedResultsProvider.CATEGORY);
+                boolean vulnerable =
+                        Boolean.parseBoolean(
+                                record.get(ExpectedResultsProvider.REAL_VULNERABILITY));
+                int cwe = Integer.parseInt(record.get(ExpectedResultsProvider.CWE));
+                int number =
+                        org.owasp.benchmarkutils.score.parsers.Reader.testNumber(
+                                name, testCaseName);
+
+                expected.put(number, new ExpectedTestCase(name, category, cwe, vulnerable));
+            }
+        }
+        return expected;
+    }
+
+    public static void main(String[] args) {
+        DetectExtraCWEs detector = new DetectExtraCWEs();
+        detector.processCommandLineArgs(args);
+        detector.run();
+    }
+}

--- a/plugin/src/test/java/org/owasp/benchmarkutils/tools/CodeBlockSupportResultsTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/tools/CodeBlockSupportResultsTest.java
@@ -1,0 +1,106 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ */
+package org.owasp.benchmarkutils.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class CodeBlockSupportResultsTest {
+
+    @Test
+    void constructsSinkWithCategory() {
+        CodeBlockSupportResults r = new CodeBlockSupportResults("MySink", "SINK", true);
+        r.vulnCat = "sqli";
+
+        assertEquals("MySink", r.name);
+        assertEquals("SINK", r.type);
+        assertTrue(r.truePositive);
+        assertEquals("sqli", r.vulnCat);
+    }
+
+    @Test
+    void isolationSetsAreInitializedEmpty() {
+        CodeBlockSupportResults r = new CodeBlockSupportResults("test", "SOURCE", false);
+
+        assertNotNull(r.fnTestCases);
+        assertNotNull(r.isolatedFnCause);
+        assertNotNull(r.isolatedFpCause);
+        assertTrue(r.fnTestCases.isEmpty());
+        assertTrue(r.isolatedFnCause.isEmpty());
+        assertTrue(r.isolatedFpCause.isEmpty());
+    }
+
+    @Test
+    void toIsolationStringForSinkIncludesCategory() {
+        CodeBlockSupportResults r = new CodeBlockSupportResults("WeakCipher", "SINK", true);
+        r.vulnCat = "crypto";
+        r.isolatedFnCause.add("BenchmarkTest00001");
+        r.isolatedFnCause.add("BenchmarkTest00002");
+
+        String result = r.toIsolationString();
+
+        assertTrue(result.contains("[SINK]"), "Should include type");
+        assertTrue(result.contains("WeakCipher"), "Should include name");
+        assertTrue(result.contains("(crypto)"), "Sink should include category");
+        assertTrue(result.contains("2 FNs isolated"), "Should count FN causes");
+    }
+
+    @Test
+    void toIsolationStringForSourceOmitsCategory() {
+        CodeBlockSupportResults r = new CodeBlockSupportResults("HttpParam", "SOURCE", false);
+
+        String result = r.toIsolationString();
+
+        assertTrue(result.contains("[SOURCE]"));
+        assertTrue(result.contains("HttpParam"));
+        assertTrue(result.contains("0 FNs isolated"));
+    }
+
+    @Test
+    void toIsolationStringForEmptyDataflowUsesNoDataFlowName() {
+        CodeBlockSupportResults r = new CodeBlockSupportResults("", "DATAFLOW", false);
+
+        String result = r.toIsolationString();
+
+        assertTrue(
+                result.contains("NoDataFlow"),
+                "Empty dataflow name should display as NoDataFlow");
+    }
+
+    @Test
+    void toIsolationStringIncludesFpCountWhenPresent() {
+        CodeBlockSupportResults r = new CodeBlockSupportResults("SafeEncoder", "DATAFLOW", false);
+        r.isolatedFpCause.add("BenchmarkTest00010");
+
+        String result = r.toIsolationString();
+
+        assertTrue(result.contains("1 FPs isolated"), "Should include FP isolation count");
+    }
+
+    @Test
+    void toIsolationStringOmitsFpSectionWhenEmpty() {
+        CodeBlockSupportResults r = new CodeBlockSupportResults("Sink1", "SINK", true);
+        r.vulnCat = "xss";
+
+        String result = r.toIsolationString();
+
+        assertTrue(
+                !result.contains("FPs isolated"),
+                "Should not mention FPs when isolatedFpCause is empty");
+    }
+}


### PR DESCRIPTION
# PR: Implement Code Block Failure Detection (Issue #5) and Extra CWE Detector (Issue #6)

## Summary

This PR completes the `CalculateToolCodeBlocksSupport` tool (Issue #5) and adds a new `DetectExtraCWEs` tool (Issue #6). Both are standalone Java tools in the `tools/` package that analyze which code constructs cause security tools to fail on OWASP Benchmark test suites.

## What Changed

### 1. `CodeBlockSupportResults.java` (modified)

Added fields for Issue #5's isolation analysis:

- `Set<String> fnTestCases` -- tracks which FN test cases use this snippet
- `Set<String> isolatedFnCause` -- FNs where THIS snippet is the single unsupported one (isolated root cause)
- `Set<String> isolatedFpCause` -- FPs where THIS snippet is the single safe snippet the tool fails to recognize
- `toIsolationString()` -- formatted output for isolated root cause reporting

These track actual test case names (not just counts), enabling bidirectional lookup: given a snippet, find all test cases it causes to fail; given a test case, find which snippet is the likely root cause.

### 2. `CalculateToolCodeBlocksSupport.java` (modified)

Three additions to Dave's existing implementation:

**A. Single-unknown isolation (Issue #5 Pass 2)**

After Pass 1 marks supported snippets from TPs, a new pass iterates each FN test case and counts how many of its snippets are NOT supported:

- **0 unknown**: All snippets are individually understood, but the tool still misses the vuln. This is a "combination failure" -- the tool can't handle the specific combination of source + dataflow + sink. These are reported separately.
- **1 unknown**: That single unsupported snippet is the likely root cause. Added to `isolatedFnCause` on the snippet. These are the most actionable findings.
- **2+ unknown**: Ambiguous -- can't isolate which snippet is the problem. Skipped.

**B. FP isolation (Issue #5 Stage 2)**

For each FP test case (tool flags a safe test case as vulnerable), identifies which snippet(s) make the test case safe using the `truePositive` metadata from the `.xml` files:

- If exactly 1 snippet is the "safe" component and the tool still flags it, that snippet is reported as an isolated FP cause.
- Sanity check: FP test cases where ALL snippets are individually "supported" from TP analysis are flagged. The tool understands each part but gets confused by the combination.

**C. Scorecard directory support**

The `-r` parameter now accepts either a single CSV file (original behavior) or a directory path. When given a directory, it discovers all `*Scorecard_for_*.csv` files and processes each tool sequentially. Each tool gets its own analysis section in the output.

### 3. `DetectExtraCWEs.java` (new)

Implements Issue #6. A standalone Java tool that detects CWE findings outside expected test cases.

**How it works:**

1. Loads the expected results CSV to build a map of `{test_number -> (name, category, cwe)}`
2. For each raw tool result file in the results directory, uses the existing `Reader.allReaders()` parsers (57 parsers covering FindBugs, PMD, ZAP, Semgrep, Checkmarx, Fortify, etc.)
3. For each finding the tool reports, checks if the reported CWE matches the expected CWE for that test case

**Two modes:**

- **Normal**: Reports findings where a known benchmark CWE (one of the 11 categories) is detected in a test case for a different CWE. Example: tool reports CWE-89 (SQLi) in BenchmarkTest00003 which is actually a hash (CWE-328) test case.
- **Hard**: Also reports findings where a CWE not in the benchmark's expected set is detected. Example: tool reports CWE-200 (Information Disclosure) which is not one of the 11 tested categories.

**Known limitation**: Existing Reader parsers filter findings at the parser level -- most parsers only retain findings in `BenchmarkTest*` files and discard findings in helper classes (e.g., `DatabaseHelper.java`). Detecting extra CWEs in non-test-case infrastructure files would require extending individual parsers, which is a separate effort.

## Usage

### Issue #5: Code Block Analysis

```bash
# Single tool
java -cp target/classes:... org.owasp.benchmarkutils.tools.CalculateToolCodeBlocksSupport \
  -f data/benchmark-attack-http.xml \
  -r scorecard/Benchmark_v1.2_Scorecard_for_FBwFindSecBugs.csv

# All tools in a directory
java -cp target/classes:... org.owasp.benchmarkutils.tools.CalculateToolCodeBlocksSupport \
  -f data/benchmark-attack-http.xml \
  -r scorecard/

# Via Maven
mvn benchmarkutils:calculate-codeblock-support \
  -DcrawlerFile=data/benchmark-attack-http.xml \
  -DresultsCSVFile=scorecard/
```

### Issue #6: Extra CWE Detector

```bash
java -cp target/classes:... org.owasp.benchmarkutils.tools.DetectExtraCWEs \
  -e expectedresults-1.2.csv \
  -r results/ \
  -m both

# Modes: normal, hard, both (default: both)
```

## Output Examples

### Issue #5 Output (per tool)

```
=== Tool: FBwFindSecBugs ===

Always FN Codeblock type: SINK (cmdi), name: RuntimeExec-S^-S[]-F.code, ...
...

--- Pass 2: Isolated FN Root Causes ---
  [SINK] RuntimeExec-S^-S[]-F.code (cmdi) -- 6 FNs isolated to this snippet
  [DATAFLOW] Reflection.code -- 15 FNs isolated to this snippet
  Combination failures (all snippets supported, tool still misses): 3

--- Sanity Check: FPs where all snippets are supported (2) ---
  Testcase #: 1234, Category: weakrand, ...

--- Stage 2: FP Root Causes (safe snippets tool doesn't recognize) ---
  [SINK] MessageDigestGetInstance-S-P2.code (hash, safe) -- 22 FPs isolated to this snippet
  [DATAFLOW] SafeQuestionmarkConditional.code (safe) -- 18 FPs isolated to this snippet
```

### Issue #6 Output (per tool)

```
=== FBwFindSecBugs v1.4.6 ===
  NORMAL: Known CWEs in wrong test cases (5 findings):
    CWE-89 found in 3 non-matching test cases:
      BenchmarkTest00442 (expected CWE-328)
      BenchmarkTest00891 (expected CWE-79)
      BenchmarkTest01234 (expected CWE-22)
  HARD: Non-benchmark CWEs detected (2 findings):
    CWE-200 found in 2 test cases:
      BenchmarkTest00100 (expected CWE-89)
```

## Design Decisions

1. **Kept Dave's existing analysis passes intact.** The new Pass 2 and Stage 2 are additive -- they run after the original analysis and produce additional output sections.

2. **Reused existing Reader parsers for Issue #6** rather than writing new XML parsers. This means all 57 tool formats are supported automatically. The tradeoff is that findings in non-test-case files are not captured (parsers filter them).

3. **Single-unknown isolation produces the most actionable results.** When a tool misses a vulnerability and exactly one snippet in that test case is unsupported, that snippet is almost certainly the cause. This is the core insight from Dave's Issue #5 spec.

4. **Combination failures are reported separately.** When all snippets are individually supported but the tool still fails, the specific combination is the problem -- not any individual snippet. These need manual investigation.
