### PR TITLE
fix: Add Unmapped CWE/Finding Warnings to All Parsers

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/AppScanDynamicReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/AppScanDynamicReader.java
@@ -198,6 +198,8 @@ public class AppScanDynamicReader extends Reader {
                 // case "Weak Encryption" : return 327;
                 // case "XPath Injection" : return 643;
         }
+        System.out.println(
+                "INFO: AppScan Dynamic - unmapped CWE: " + id + ". Passing through as-is.");
         return id;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/AppScanSourceReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/AppScanSourceReader.java
@@ -178,6 +178,7 @@ public class AppScanSourceReader extends Reader {
             case "Vulnerability.Validation.Required":
                 return CweNumber.TRUST_BOUNDARY_VIOLATION;
         }
+        System.out.println("WARNING: AppScan Source-Unmapped finding type: " + vtype);
         return 0;
     }
 

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/BearerReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/BearerReader.java
@@ -60,6 +60,8 @@ public class BearerReader extends Reader {
             case 327:
                 return CweNumber.WEAK_HASH_ALGO;
             default:
+                System.out.println(
+                        "INFO: Bearer - unmapped CWE: " + cwe + ". Passing through as-is.");
                 return cwe;
         }
     }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxESReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxESReader.java
@@ -127,6 +127,8 @@ public class CheckmarxESReader extends Reader {
             case 338:
                 return CweNumber.WEAK_RANDOM;
         }
+        System.out.println(
+                "INFO: Checkmarx ES - unmapped CWE: " + cwe + ". Passing through as-is.");
         return cwe;
     }
 

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CheckmarxReader.java
@@ -214,6 +214,8 @@ public class CheckmarxReader extends Reader {
             case 338:
                 return CweNumber.WEAK_RANDOM;
         }
+        System.out.println(
+                "INFO: Checkmarx - unmapped CWE: " + cwe + ". Passing through as-is.");
         return cwe;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CoverityReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/CoverityReader.java
@@ -176,6 +176,12 @@ public class CoverityReader extends Reader {
                     cwe_string = "89";
                 } else if (checker_name.equals("ldap_injection")) {
                     cwe_string = "90";
+                } else {
+                    System.out.println(
+                            "WARNING: Coverity-Unmapped checker: "
+                                    + checker_name
+                                    + " / "
+                                    + subcategory);
                 }
                 int cwe = fixCWE(cwe_string);
                 if (cwe <= 0) {

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/FluidAttacksReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/FluidAttacksReader.java
@@ -100,6 +100,7 @@ public class FluidAttacksReader extends Reader {
             case "xpathi":
                 return 643;
             default:
+                System.out.println("WARNING: Fluid Attacks-Unmapped category: " + cwe);
                 return 0;
         }
     }
@@ -131,6 +132,8 @@ public class FluidAttacksReader extends Reader {
             case "643":
                 return "xpathi";
             default:
+                System.out.println(
+                        "INFO: Fluid Attacks - unmapped CWE: " + cwe + ". Categorized as other.");
                 return "other";
         }
     }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanSourceReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanSourceReader.java
@@ -167,8 +167,6 @@ public class HCLAppScanSourceReader extends Reader {
     }
 
     private void reportWarning(String message) {
-        if (System.getProperty("DEBUG") != null) {
-            System.out.println(message);
-        }
+        System.out.println(message);
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/HCLAppScanStandardReader.java
@@ -138,6 +138,12 @@ public class HCLAppScanStandardReader extends Reader {
             return CweNumber.DONTCARE;
         }
 
+        System.out.println(
+                "INFO: HCL AppScan Standard - unmapped finding type: "
+                        + vtype
+                        + " (CWE "
+                        + xmlCwe
+                        + "). Passing through as-is.");
         return xmlCwe;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/KiuwanReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/KiuwanReader.java
@@ -125,10 +125,11 @@ public class KiuwanReader extends Reader {
 
         if (cwe == 564) {
             cwe = CweNumber.SQL_INJECTION;
-        }
-
-        if (cwe == 77) {
+        } else if (cwe == 77) {
             cwe = CweNumber.COMMAND_INJECTION;
+        } else {
+            System.out.println(
+                    "INFO: Kiuwan - unmapped CWE: " + cwe + ". Passing through as-is.");
         }
         return cwe;
     }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/NetsparkerReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/NetsparkerReader.java
@@ -129,6 +129,8 @@ public class NetsparkerReader extends Reader {
                 //        case "trust-boundary-violation"  :  return 501;  // trust boundary
                 //        case "xxe"                       :  return 611;  // xml entity
         }
+        System.out.println(
+                "INFO: Netsparker - unmapped CWE: " + cwe + ". Passing through as-is.");
         return cwe;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/ParasoftReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/ParasoftReader.java
@@ -188,6 +188,7 @@ public class ParasoftReader extends Reader {
                 //        case "Weak Cryptographic Hash" : return 328;
                 //        case "Weak Encryption" : return 327;
         }
+        System.out.println("WARNING: Parasoft-Unmapped finding category: " + cat);
         return -1;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/ShiftLeftReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/ShiftLeftReader.java
@@ -91,7 +91,8 @@ public class ShiftLeftReader extends Reader {
             case "xss":
                 return 79;
             default:
-                throw new RuntimeException("Unknown category: " + category);
+                System.out.println("WARNING: ShiftLeft-Unknown category: " + category);
+                return 0;
         }
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SourceMeterReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/SourceMeterReader.java
@@ -125,6 +125,7 @@ public class SourceMeterReader extends Reader {
                 //        case "xxe":
                 //            return 611; // xml entity
         }
+        System.out.println("WARNING: SourceMeter-Unmapped vulnerability type: " + vuln);
         return 0;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/VeracodeReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/VeracodeReader.java
@@ -135,6 +135,8 @@ public class VeracodeReader extends Reader {
         if (cwe == 80) return 79;
         if (cwe == 331) return 330;
         if (cwe == 91) return 643;
+        System.out.println(
+                "INFO: Veracode - unmapped CWE: " + cwe + ". Passing through as-is.");
         return cwe;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/VisualCodeGrepperReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/VisualCodeGrepperReader.java
@@ -161,8 +161,9 @@ public class VisualCodeGrepperReader extends Reader {
                 return CweNumber.TRUST_BOUNDARY_VIOLATION;
 
             default:
-                return 00; // System.out.println( "Unknown vuln category for VisualCodeGrepper: " +
-                // cat );
+                System.out.println(
+                        "Unknown vuln category for VisualCodeGrepper: " + cat);
+                return 00;
         }
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/W3AFReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/W3AFReader.java
@@ -129,6 +129,7 @@ public class W3AFReader extends Reader {
                 //        case "trust-boundary-violation"  :  return 501;  // trust boundary
                 //        case "xxe"                       :  return 611;  // xml entity
         }
+        System.out.println("WARNING: W3AF-Unmapped finding name: " + name);
         return 0000;
     }
 }

--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/WebInspectReader.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/parsers/WebInspectReader.java
@@ -177,6 +177,7 @@ public class WebInspectReader extends Reader {
                 //        case "trust-boundary-violation"  :  return 501;  // trust boundary
                 //        case "xxe"                       :  return 611;  // xml entity
         }
+        System.out.println("WARNING: WebInspect-Unmapped rule: " + rule);
         return 0;
     }
 }

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/ShiftLeftReaderTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/parsers/ShiftLeftReaderTest.java
@@ -1,0 +1,71 @@
+/**
+ * OWASP Benchmark Project
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author TheAuditorTool
+ * @created 2026
+ */
+package org.owasp.benchmarkutils.score.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.owasp.benchmarkutils.score.CweNumber;
+import org.owasp.benchmarkutils.score.ResultFile;
+import org.owasp.benchmarkutils.score.TestSuiteResults;
+
+public class ShiftLeftReaderTest extends ReaderTestBase {
+
+    @TempDir Path tempDir;
+
+    private ResultFile createSlFile(String content) throws Exception {
+        File slFile = tempDir.resolve("Benchmark_ShiftLeft.sl").toFile();
+        Files.writeString(slFile.toPath(), content);
+        return new ResultFile(slFile);
+    }
+
+    @Test
+    void readerHandlesKnownCategories() throws Exception {
+        ResultFile resultFile = createSlFile("00001,sqli\n00002,xss\n");
+
+        ShiftLeftReader reader = new ShiftLeftReader();
+        TestSuiteResults result = reader.parse(resultFile);
+
+        assertTrue(result.isCommercial());
+        assertEquals("ShiftLeft", result.getToolName());
+        assertEquals(2, result.getTotalResults());
+        assertEquals(CweNumber.SQL_INJECTION, result.get(1).get(0).getCWE());
+        assertEquals(CweNumber.XSS, result.get(2).get(0).getCWE());
+    }
+
+    @Test
+    void unknownCategoryReturnsZeroInsteadOfThrowing() throws Exception {
+        ResultFile resultFile = createSlFile("00003,unknowncategory\n");
+
+        ShiftLeftReader reader = new ShiftLeftReader();
+
+        TestSuiteResults result =
+                assertDoesNotThrow(
+                        () -> reader.parse(resultFile),
+                        "Unknown category must not throw RuntimeException");
+
+        assertEquals(1, result.getTotalResults());
+        assertEquals(0, result.get(3).get(0).getCWE(), "Unknown category should map to CWE 0");
+    }
+}


### PR DESCRIPTION
# Add Unmapped CWE/Finding Warnings to All Parsers

**Closes #7**

---

## What This Does

When a security tool reports a vulnerability type that a parser doesn't recognize, the parser should print a message so you know about it. Some parsers already did this, but others were silently discarding the finding. This update makes all parsers consistent: they all print a message now.

**No scoring logic was changed.** The only difference is that you'll see console messages when a parser encounters something new. The return values (what the scoring engine actually uses) are identical to before.

## What You'll See in the Console

For parsers where the finding would be **lost** (returns 0 or -1):
```
WARNING: WebInspect-Unmapped rule: some-new-rule-id
WARNING: Parasoft-Unmapped finding category: SomeNewCategory
```

For parsers where the finding **survives** but wasn't explicitly mapped (CWE passes through):
```
INFO: Checkmarx - unmapped CWE: 917. Passing through as-is.
INFO: Veracode - unmapped CWE: 502. Passing through as-is.
```

These messages tell you exactly which parser saw the new value and what that value is, so you can add the proper mapping when you're ready.

## Files Changed (18 files, all in `score/parsers/`)

### Parsers that were silently dropping findings (added WARNING)

| Parser | What was silent |
|--------|----------------|
| AppScanSourceReader | Unknown finding types returned 0 |
| FluidAttacksReader | Unknown categories returned 0 |
| ParasoftReader | Unknown categories returned -1 |
| SourceMeterReader | Unknown vulnerability types returned 0 |
| W3AFReader | Unknown finding names returned 0 |
| WebInspectReader | Unknown rules returned 0 |

### Parsers that were silently passing CWEs through (added INFO)

| Parser | What was silent |
|--------|----------------|
| AppScanDynamicReader | All CWEs passed through with no mapping |
| BearerReader | Unmapped CWEs passed through |
| CheckmarxESReader | Unmapped CWEs passed through |
| CheckmarxReader | Unmapped CWEs passed through |
| CoverityReader | Unknown checker names in V2 format |
| HCLAppScanStandardReader | Unknown finding types with raw CWE |
| KiuwanReader | CWEs not in the fix-up table |
| NetsparkerReader | CWEs not in the (very small) switch |
| VeracodeReader | CWEs not in the translation list |

### Special cases

| Parser | What changed | Why |
|--------|-------------|-----|
| VisualCodeGrepperReader | Uncommented an existing `println` that was commented out | The warning was already written but disabled |
| ShiftLeftReader | Changed `throw RuntimeException` to `println` + `return 0` | Unknown categories were crashing the parser instead of warning |
| HCLAppScanSourceReader | Removed the `-DDEBUG` gate on warnings | Warnings were only printed if you set a special JVM property |

## What Was NOT Changed (and why)

**Parsers that already warn properly** (30 parsers) — no changes needed. These include: AcunetixReader, BurpReader, CASTAIPReader, CheckmarxIASTReader, ContrastAssessReader, CrashtestReader, FortifyReader, HorusecReader, InsiderReader, NJSScanReader, PMDReader, QualysWASReader, Rapid7Reader, ReshiftReader, SeekerReader, SemgrepReader, ShiftLeftScanReader, SnappyTickReader, SonarQubeJsonReader, SonarQubeReader, ThunderScanReader, WapitiReader, WapitiJsonReader, ZapJsonReader, and all SARIF-based readers.

**Parsers with no CWE mapping** (7 parsers) — these read the CWE number directly from the tool's output, so there's nothing to map and nothing to warn about: BlackDuckReader, FaastReader, FusionLiteInsightReader, JuliaReader, MendReader, NoisyCricketReader, ScnrReader.

**Parsers from the original issue that no longer exist:** HdivReader, LGTMReader, XanitizerReader, ShiftLeftNGSASTReader, ShiftLeftNGSASTReaderJSON. These were either removed or renamed since the issue was filed.

## How to Verify

Run scorecard generation against any tool results you already have. The scorecards themselves will be identical — the only new output is console messages for unmapped values.
