### PR TITLE
Fix commercial averages scoring bug: restore * 100 scaling

### DIFF
--- a/plugin/src/main/java/org/owasp/benchmarkutils/score/report/ScatterVulns.java
+++ b/plugin/src/main/java/org/owasp/benchmarkutils/score/report/ScatterVulns.java
@@ -378,7 +378,7 @@ public class ScatterVulns extends ScatterPlot {
                 if (ch == 'Z') ch = 'a';
                 else ch++;
 
-                noncommercialTotalScore += categoryMetrics.score;
+                noncommercialTotalScore += categoryMetrics.score * 100;
                 noncommercialTotalPrecision += categoryMetrics.precision;
                 noncommercialTotalTPR += categoryMetrics.truePositiveRate;
                 noncommercialTotalFPR += categoryMetrics.falsePositiveRate;
@@ -445,7 +445,7 @@ public class ScatterVulns extends ScatterPlot {
 
                 this.commercialToolCount++;
                 this.overallToolCount++;
-                double score = categoryMetrics.score;
+                double score = categoryMetrics.score * 100;
                 double tpr = categoryMetrics.truePositiveRate;
                 double fpr = categoryMetrics.falsePositiveRate;
                 // don't show the commercial tool results if in 'show ave only mode'

--- a/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/CommercialAveragesTableTest.java
+++ b/plugin/src/test/java/org/owasp/benchmarkutils/score/report/html/CommercialAveragesTableTest.java
@@ -52,16 +52,16 @@ class CommercialAveragesTableTest {
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Availability",
-                                                        50.0,
-                                                        6.666666666666667,
-                                                        5.0,
+                                                        0.5,
+                                                        0.06666666666666667,
+                                                        0.05,
                                                         35))
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Command Injection",
-                                                        51.85185185185185,
-                                                        93.33333333333333,
-                                                        65.0,
+                                                        0.5185185185185185,
+                                                        0.9333333333333333,
+                                                        0.65,
                                                         35))
                                         .build())
                         .build();
@@ -74,16 +74,16 @@ class CommercialAveragesTableTest {
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Availability",
-                                                        73.21428571428571,
-                                                        100.0,
-                                                        53.0622009569378,
+                                                        0.7321428571428571,
+                                                        1.0,
+                                                        0.530622009569378,
                                                         455))
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Command Injection",
-                                                        95.23809523809523,
-                                                        58.130081300813008,
-                                                        20.4784688995215311,
+                                                        0.9523809523809523,
+                                                        0.58130081300813008,
+                                                        0.204784688995215311,
                                                         455))
                                         .build())
                         .build();
@@ -155,16 +155,16 @@ class CommercialAveragesTableTest {
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Availability",
-                                                        50.0,
-                                                        66.666666666666667,
-                                                        5.0,
+                                                        0.5,
+                                                        0.66666666666666667,
+                                                        0.05,
                                                         35))
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Command Injection",
-                                                        51.85185185185185,
-                                                        93.33333333333333,
-                                                        35.0,
+                                                        0.5185185185185185,
+                                                        0.9333333333333333,
+                                                        0.35,
                                                         35))
                                         .build())
                         .build();
@@ -211,16 +211,16 @@ class CommercialAveragesTableTest {
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Availability",
-                                                        5.0,
-                                                        6.66666666666667,
-                                                        65.0,
+                                                        0.05,
+                                                        0.0666666666666667,
+                                                        0.65,
                                                         35))
                                         .addCategoryResult(
                                                 new CategoryMetrics(
                                                         "Command Injection",
-                                                        51.85185185185185,
-                                                        33.33333333333333,
-                                                        95.0,
+                                                        0.5185185185185185,
+                                                        0.3333333333333333,
+                                                        0.95,
                                                         35))
                                         .build())
                         .build();


### PR DESCRIPTION
  Summary

  - Commercial average scores displayed as 0/1 instead of proper percentages (e.g., 47, 38)
  - Root cause: the CategoryResults -> CategoryMetrics refactor dropped * 100 from the commercial score variable in ScatterVulns.makeLegend()
  - Non-commercial score accumulation also missing * 100, causing overall average to mix 0-1 rates with 0-100 percentages
  - Test values in CommercialAveragesTableTest were simultaneously scaled from 0-1 to 0-100 during refactor, masking the bug (two errors cancelling out)

  Changes

  - ScatterVulns.java:381 - Add * 100 to non-commercial score accumulation
  - ScatterVulns.java:448 - Add * 100 to commercial score variable
  - CommercialAveragesTableTest.java - Revert test CategoryMetrics values to 0-1 rates matching production calculateMetrics() output

  All existing test assertions unchanged — same expected output (47, 38, 62, 58, etc.)

  Additional bugs found in generalizeScoring

  1. Unused variable — ScatterVulns.java:434: toolMetrics fetched but never referenced
  2. Asymmetric comparison — ScatterVulns.java:479: commercial low uses <= vs non-commercial < at line 387
  3. Latent NPE — Tool.getCategoryGroupMetrics(): per-category lookup can return null silently
  4. ToolReport triangle indicators — ToolReport.java:230,247,263: 100 * x - y where both x and y are 0-1 rates; above/below-average indicators always wrong